### PR TITLE
Fix timers in web workers

### DIFF
--- a/crates/timers/src/callback.rs
+++ b/crates/timers/src/callback.rs
@@ -1,6 +1,6 @@
 //! Callback-style timer APIs.
 
-use super::{clear_interval, clear_timeout, set_interval, set_timeout};
+use super::sys::*;
 use std::fmt;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;

--- a/crates/timers/src/callback.rs
+++ b/crates/timers/src/callback.rs
@@ -1,6 +1,6 @@
 //! Callback-style timer APIs.
 
-use super::window;
+use super::{clear_interval, clear_timeout, set_interval, set_timeout};
 use std::fmt;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -20,7 +20,7 @@ pub struct Timeout {
 impl Drop for Timeout {
     fn drop(&mut self) {
         if let Some(id) = self.id {
-            window().clear_timeout_with_handle(id);
+            clear_timeout(id);
         }
     }
 }
@@ -50,12 +50,10 @@ impl Timeout {
     {
         let closure = Closure::once(callback);
 
-        let id = window()
-            .set_timeout_with_callback_and_timeout_and_arguments_0(
-                closure.as_ref().unchecked_ref::<js_sys::Function>(),
-                millis as i32,
-            )
-            .unwrap_throw();
+        let id = set_timeout(
+            closure.as_ref().unchecked_ref::<js_sys::Function>(),
+            millis as i32,
+        );
 
         Timeout {
             id: Some(id),
@@ -125,7 +123,7 @@ pub struct Interval {
 impl Drop for Interval {
     fn drop(&mut self) {
         if let Some(id) = self.id {
-            window().clear_interval_with_handle(id);
+            clear_interval(id);
         }
     }
 }
@@ -158,12 +156,10 @@ impl Interval {
             callback();
         }) as Box<FnMut()>);
 
-        let id = window()
-            .set_interval_with_callback_and_timeout_and_arguments_0(
-                closure.as_ref().unchecked_ref::<js_sys::Function>(),
-                millis as i32,
-            )
-            .unwrap_throw();
+        let id = set_interval(
+            closure.as_ref().unchecked_ref::<js_sys::Function>(),
+            millis as i32,
+        );
 
         Interval {
             id: Some(id),

--- a/crates/timers/src/future.rs
+++ b/crates/timers/src/future.rs
@@ -1,6 +1,6 @@
 //! `Future`- and `Stream`-backed timers APIs.
 
-use super::{clear_interval, clear_timeout, set_interval, set_timeout};
+use super::sys::*;
 use futures::prelude::*;
 use futures::sync::mpsc;
 use std::fmt;

--- a/crates/timers/src/future.rs
+++ b/crates/timers/src/future.rs
@@ -1,6 +1,6 @@
 //! `Future`- and `Stream`-backed timers APIs.
 
-use super::window;
+use super::{clear_interval, clear_timeout, set_interval, set_timeout};
 use futures::prelude::*;
 use futures::sync::mpsc;
 use std::fmt;
@@ -56,7 +56,7 @@ pub struct TimeoutFuture {
 impl Drop for TimeoutFuture {
     fn drop(&mut self) {
         if let Some(id) = self.id {
-            window().clear_timeout_with_handle(id);
+            clear_timeout(id);
         }
     }
 }
@@ -84,11 +84,7 @@ impl TimeoutFuture {
     pub fn new(millis: u32) -> TimeoutFuture {
         let mut id = None;
         let promise = js_sys::Promise::new(&mut |resolve, _reject| {
-            id = Some(
-                window()
-                    .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, millis as i32)
-                    .unwrap_throw(),
-            );
+            id = Some(set_timeout(&resolve, millis as i32));
         });
         debug_assert!(id.is_some());
         let inner = JsFuture::from(promise);
@@ -173,7 +169,7 @@ impl IntervalStream {
 impl Drop for IntervalStream {
     fn drop(&mut self) {
         if let Some(id) = self.id {
-            window().clear_interval_with_handle(id);
+            clear_interval(id);
         }
     }
 }
@@ -192,14 +188,10 @@ impl Stream for IntervalStream {
 
     fn poll(&mut self) -> Poll<Option<()>, ()> {
         if self.id.is_none() {
-            self.id = Some(
-                window()
-                    .set_interval_with_callback_and_timeout_and_arguments_0(
-                        self.closure.as_ref().unchecked_ref::<js_sys::Function>(),
-                        self.millis as i32,
-                    )
-                    .unwrap_throw(),
-            );
+            self.id = Some(set_interval(
+                self.closure.as_ref().unchecked_ref::<js_sys::Function>(),
+                self.millis as i32,
+            ));
         }
 
         self.inner.poll()

--- a/crates/timers/src/lib.rs
+++ b/crates/timers/src/lib.rs
@@ -67,25 +67,9 @@ TODO
 #[cfg(feature = "futures")]
 extern crate futures_rs as futures;
 
-use js_sys::Function;
-use wasm_bindgen::prelude::*;
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(js_name = "setTimeout")]
-    pub fn set_timeout(handler: &Function, timeout: i32) -> i32;
-
-    #[wasm_bindgen(js_name = "clearTimeout")]
-    pub fn clear_timeout(token: i32);
-
-    #[wasm_bindgen(js_name = "setInterval")]
-    pub fn set_interval(handler: &Function, timeout: i32) -> i32;
-
-    #[wasm_bindgen(js_name = "clearInterval")]
-    pub fn clear_interval(token: i32);
-}
-
 pub mod callback;
 
 #[cfg(feature = "futures")]
 pub mod future;
+
+mod sys;

--- a/crates/timers/src/lib.rs
+++ b/crates/timers/src/lib.rs
@@ -67,10 +67,22 @@ TODO
 #[cfg(feature = "futures")]
 extern crate futures_rs as futures;
 
+use js_sys::Function;
 use wasm_bindgen::prelude::*;
 
-fn window() -> web_sys::Window {
-    web_sys::window().unwrap_throw()
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = "setTimeout")]
+    pub fn set_timeout(handler: &Function, timeout: i32) -> i32;
+
+    #[wasm_bindgen(js_name = "clearTimeout")]
+    pub fn clear_timeout(token: i32);
+
+    #[wasm_bindgen(js_name = "setInterval")]
+    pub fn set_interval(handler: &Function, timeout: i32) -> i32;
+
+    #[wasm_bindgen(js_name = "clearInterval")]
+    pub fn clear_interval(token: i32);
 }
 
 pub mod callback;

--- a/crates/timers/src/sys.rs
+++ b/crates/timers/src/sys.rs
@@ -1,0 +1,20 @@
+//! Raw bindings to the Javascript APIs we need, namely set(Timeout|Interval) and clear(Timeout|Interval).
+//! Depending on how rustwasm/wasm-bindgen#1046 is resolved, we may be able to remove this at a later date.
+
+use js_sys::Function;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_name = "setTimeout")]
+    pub fn set_timeout(handler: &Function, timeout: i32) -> i32;
+
+    #[wasm_bindgen(js_name = "clearTimeout")]
+    pub fn clear_timeout(token: i32);
+
+    #[wasm_bindgen(js_name = "setInterval")]
+    pub fn set_interval(handler: &Function, timeout: i32) -> i32;
+
+    #[wasm_bindgen(js_name = "clearInterval")]
+    pub fn clear_interval(token: i32);
+}


### PR DESCRIPTION
@fitzgen / @OddCoincidence 

`gloo-timers` doesn't work in web workers at all right now, because `web_sys::window()` wants to cast the global namespace into a `Window` object, which doesn't exist in worker contexts. So I just dropped us back down to raw `#[wasm_bindgen]` methods.

This might be something better fixed in wasm-bindgen later though. There does exist this thing: [WindowOrWorkerGlobalScope](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope) which is a nice view over what global methods are available in both Window and Worker contexts. However as stated in that documentation:

> Note: WindowOrWorkerGlobalScope is a mixin and not an interface; you can't actually create an object of type WindowOrWorkerGlobalScope.

So I guess this thing is probably not mentioned anywhere in the IDLs that are being used to build the `web-sys` crate.

~Also, the `Interval` stuff wasn't actually working properly at all, it was consuming the callback from the `Option` which meant only the first interval callback worked and all subsequent ones failed.~ See #57