### PR TITLE
gloo-timers: don't consume callback in Interval closure

### DIFF
--- a/crates/timers/src/callback.rs
+++ b/crates/timers/src/callback.rs
@@ -152,11 +152,7 @@ impl Interval {
     where
         F: 'static + FnMut(),
     {
-        let mut callback = Some(callback);
-        let closure = Closure::wrap(Box::new(move || {
-            let callback = callback.as_mut().take().unwrap_throw();
-            callback();
-        }) as Box<FnMut()>);
+        let closure = Closure::wrap(Box::new(callback) as Box<FnMut()>);
 
         let id = window()
             .set_interval_with_callback_and_timeout_and_arguments_0(

--- a/crates/timers/src/callback.rs
+++ b/crates/timers/src/callback.rs
@@ -154,7 +154,7 @@ impl Interval {
     {
         let mut callback = Some(callback);
         let closure = Closure::wrap(Box::new(move || {
-            let mut callback = callback.take().unwrap_throw();
+            let callback = callback.as_mut().take().unwrap_throw();
             callback();
         }) as Box<FnMut()>);
 


### PR DESCRIPTION
Otherwise Interval only works on first callback and fails after that