### PR TITLE
Derive Debug impls

### DIFF
--- a/crates/console-timer/Cargo.toml
+++ b/crates/console-timer/Cargo.toml
@@ -11,5 +11,5 @@ features = [
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.43"
 gloo-timers = { version = "0.1.0", path = "../timers" }

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.1.25"
 wasm-bindgen-test = "0.2.37"
 
 [dev-dependencies.web-sys]
+version = "0.3.14"
 features = [
     "HtmlElement",
     "Window",

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Rust and WebAssembly Working Group"]
 edition = "2018"
 
 [dependencies]
-wasm-bindgen = "0.2.37"
+wasm-bindgen = "0.2.43"
 
 [dependencies.web-sys]
 version = "0.3.14"
@@ -18,7 +18,7 @@ features = [
 [dev-dependencies]
 js-sys = "0.3.14"
 futures = "0.1.25"
-wasm-bindgen-test = "0.2.37"
+wasm-bindgen-test = "0.2.43"
 
 [dev-dependencies.web-sys]
 version = "0.3.14"

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -225,6 +225,7 @@ thread_local! {
 ///     }
 /// }
 /// ```
+#[derive(Debug)]
 #[must_use = "event listener will never be called after being dropped"]
 pub struct EventListener {
     target: EventTarget,
@@ -578,17 +579,5 @@ impl Drop for EventListener {
                 )
                 .unwrap_throw();
         }
-    }
-}
-
-// TODO Remove this after https://github.com/rustwasm/wasm-bindgen/issues/1387 is fixed
-impl std::fmt::Debug for EventListener {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct("EventListener")
-            .field("target", &self.target)
-            .field("event_type", &self.event_type)
-            .field("callback", &"Closure { ... }")
-            .field("phase", &self.phase)
-            .finish()
     }
 }

--- a/crates/timers/Cargo.toml
+++ b/crates/timers/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Rust and WebAssembly Working Group"]
 edition = "2018"
 
 [dependencies]
-wasm-bindgen = "0.2.40"
+wasm-bindgen = "0.2.43"
 js-sys = "0.3.17"
 
 [dependencies.futures_rs]
@@ -14,11 +14,11 @@ version = "0.1.25"
 optional = true
 
 [dependencies.wasm-bindgen-futures]
-version = "0.3.17"
+version = "0.3.19"
 optional = true
 
 [dependencies.web-sys]
-version = "0.3.17"
+version = "0.3.19"
 features = [
     "Window",
 ]
@@ -29,4 +29,4 @@ futures = ["futures_rs", "wasm-bindgen-futures"]
 
 
 [dev-dependencies]
-wasm-bindgen-test = "0.2.40"
+wasm-bindgen-test = "0.2.43"

--- a/crates/timers/src/callback.rs
+++ b/crates/timers/src/callback.rs
@@ -1,7 +1,6 @@
 //! Callback-style timer APIs.
 
 use super::sys::*;
-use std::fmt;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
@@ -11,6 +10,7 @@ use wasm_bindgen::JsCast;
 ///
 /// Once scheduled, you can either `cancel` so that it doesn't run or `forget`
 /// it so that it is un-cancel-able.
+#[derive(Debug)]
 #[must_use = "timeouts cancel on drop; either call `forget` or `drop` explicitly"]
 pub struct Timeout {
     id: Option<i32>,
@@ -22,12 +22,6 @@ impl Drop for Timeout {
         if let Some(id) = self.id {
             clear_timeout(id);
         }
-    }
-}
-
-impl fmt::Debug for Timeout {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Timeout").field("id", &self.id).finish()
     }
 }
 
@@ -114,6 +108,7 @@ impl Timeout {
 ///
 /// Once scheduled, you can either `cancel` so that it ceases to fire or `forget`
 /// it so that it is un-cancel-able.
+#[derive(Debug)]
 #[must_use = "intervals cancel on drop; either call `forget` or `drop` explicitly"]
 pub struct Interval {
     id: Option<i32>,
@@ -125,12 +120,6 @@ impl Drop for Interval {
         if let Some(id) = self.id {
             clear_interval(id);
         }
-    }
-}
-
-impl fmt::Debug for Interval {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Interval").field("id", &self.id).finish()
     }
 }
 

--- a/crates/timers/src/future.rs
+++ b/crates/timers/src/future.rs
@@ -3,7 +3,6 @@
 use super::sys::*;
 use futures::prelude::*;
 use futures::sync::mpsc;
-use std::fmt;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
@@ -47,6 +46,7 @@ use wasm_bindgen_futures::JsFuture;
 ///         })
 /// );
 /// ```
+#[derive(Debug)]
 #[must_use = "futures do nothing unless polled or spawned"]
 pub struct TimeoutFuture {
     id: Option<i32>,
@@ -92,14 +92,6 @@ impl TimeoutFuture {
     }
 }
 
-impl fmt::Debug for TimeoutFuture {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("TimeoutFuture")
-            .field("id", &self.id)
-            .finish()
-    }
-}
-
 impl Future for TimeoutFuture {
     type Item = ();
     type Error = ();
@@ -121,6 +113,7 @@ impl Future for TimeoutFuture {
 /// you can `drop` the stream.
 ///
 /// An interval stream will never resolve to `Err`.
+#[derive(Debug)]
 #[must_use = "streams do nothing unless polled or spawned"]
 pub struct IntervalStream {
     millis: u32,
@@ -171,14 +164,6 @@ impl Drop for IntervalStream {
         if let Some(id) = self.id {
             clear_interval(id);
         }
-    }
-}
-
-impl fmt::Debug for IntervalStream {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("IntervalStream")
-            .field("id", &self.id)
-            .finish()
     }
 }
 


### PR DESCRIPTION
Not sure this is an improvement, but hey, at least it fixes a TODO.

I also sneaked in a `Cargo.toml` change to avoid a warning.