### PR TITLE
Add a readme to the clock example

### DIFF
--- a/examples/clock/README.md
+++ b/examples/clock/README.md
@@ -1,0 +1,7 @@
+# Clock example
+
+This is a simple example showcasing the Gloo timers.
+
+First, [install wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) if needed.
+
+Then build the clock example by running `wasm-pack build --target no-modules` and open your browser to load `index.html`.


### PR DESCRIPTION
This is mostly useful because of the usage of '--target no-modules' as a wasm-pack option.