### PR TITLE
Make docs.rs include futures functionality

### DIFF
--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/rustwasm/gloo/tree/master/crates/file"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
 
+[package.metadata.docs.rs]
+features = ["futures"]
+
 [dependencies]
 wasm-bindgen = "0.2.54"
 js-sys = "0.3.31"

--- a/crates/file/README.md
+++ b/crates/file/README.md
@@ -20,14 +20,10 @@
   <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
 </div>
 
-Provides wrappers for working with `Blob`s and `File`s from JavaScript.
 
-A `File` is just a `Blob` with some extra data: a name and a last modified time.
+Working with files and blobs on the Web.
 
-In the File API, `Blob`s are opaque objects that lazily fetch their contained data when
-asked. This allows a `Blob` to represent some resource that isn't completely available, for
-example a WebSocket message that is being received or a file that needs to be read from disk.
+These APIs come in two flavors:
 
-You can asynchronously access the contents of the `Blob` through callbacks,
-but that is rather inconvenient, so this crate provides some functions which
-return a `Future` instead.
+1. a callback style (that more directly mimics the JavaScript APIs), and
+2. a `Future` API.

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -1,14 +1,10 @@
-//! Provides wrappers for working with `Blob`s and `File`s from JavaScript.
 //!
-//! A `File` is just a `Blob` with some extra data: a name and a last modified time.
+//! Working with files and blobs on the Web.
 //!
-//! In the File API, `Blob`s are opaque objects that lazily fetch their contained data when
-//! asked. This allows a `Blob` to represent some resource that isn't completely available, for
-//! example a WebSocket message that is being received or a file that needs to be read from disk.
+//! These APIs come in two flavors:
 //!
-//! You can asynchronously access the contents of the `Blob` through callbacks,
-//! but that is rather inconvenient, so this crate provides some functions which
-//! return a `Future` instead.
+//! 1. a callback style (that more directly mimics the JavaScript APIs), and
+//! 2. a `Future` API.
 
 mod blob;
 mod file_list;

--- a/crates/timers/Cargo.toml
+++ b/crates/timers/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/rustwasm/gloo/tree/master/crates/timers"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
 
+[package.metadata.docs.rs]
+features = ["futures"]
+
 [dependencies]
 wasm-bindgen = "0.2.54"
 js-sys = "0.3.31"


### PR DESCRIPTION
Make docs.rs builds include the futures feature.