### PR TITLE
Fix dir, dirxml macros in gloo-console

### DIFF
--- a/crates/console/src/macros.rs
+++ b/crates/console/src/macros.rs
@@ -23,18 +23,30 @@ macro_rules! debug {
 }
 
 /// Calls `console.dir()`
+/// ## Example
+/// ```no_run
+/// # use gloo_console::dir;
+/// # use js_sys::Array;
+/// dir!(Array::of2(&1.into(), &2.into()));
+/// ```
 #[macro_export]
 macro_rules! dir {
-    ($($arg:expr),+) => {
-        $crate::externs::dir($crate::__macro::JsValue::from($arg));
+    ($arg:expr) => {
+        $crate::externs::dir(&$crate::__macro::JsValue::from($arg));
     };
 }
 
 /// Calls `console.dirxml()`
+/// ## Example
+/// ```no_run
+/// # use gloo_console::dirxml;
+/// # use js_sys::Array;
+/// dirxml!(Array::of2(&1.into(), &2.into()));
+/// ```
 #[macro_export]
 macro_rules! dirxml {
-    ($($arg:expr),+) => {
-        $crate::externs::dirxml($crate::__macro::JsValue::from($arg));
+    ($arg:expr) => {
+        $crate::externs::dirxml(&$crate::__macro::JsValue::from($arg));
     };
 }
 


### PR DESCRIPTION
Noticed the discussion on discord and thought I'd contribute a fix.

Gets rid of a repetition that is not allowed according to [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/console/dir), which only mentions one single argument. Adds two examples that get picked up by doctesting to verify the fix.