### PR TITLE
utils: Add body() and document_element() getters

### DIFF
--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -20,6 +20,7 @@ version = "0.3"
 features = [
     "Document",
     "History",
+    "HtmlElement",
     "Location",
     "Window"
 ]

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -11,6 +11,18 @@ pub fn document() -> web_sys::Document {
     window().document().expect_throw("Can't find document")
 }
 
+/// Convenience function to access `document.body`.
+pub fn body() -> web_sys::HtmlElement {
+    document().body().expect_throw("Can't find document body")
+}
+
+/// Convenience function to access `document.documentElement`.
+pub fn document_element() -> web_sys::Element {
+    document()
+        .document_element()
+        .expect_throw("Can't find document element")
+}
+
 /// Convenience function to access the web_sys history.
 pub fn history() -> web_sys::History {
     window().history().expect_throw("Can't find history")


### PR DESCRIPTION
Closes #160.

Can you release #159 and this in gloo-utils 0.1.1 / gloo 0.4.1 after merging? :)