### PR TITLE
Add BrowserHistory and BrowserLocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ gloo-storage = { version = "0.2.0", path = "crates/storage" }
 gloo-render = { version = "0.1.0", path = "crates/render" }
 gloo-console = { version = "0.2.0", path = "crates/console" }
 gloo-utils = { version = "0.1.0", path = "crates/utils" }
+gloo-history = { version = "0.1.0", path = "crates/history" }
 
 [features]
 default = []
@@ -36,4 +37,5 @@ members = [
     "crates/storage",
     "crates/console",
     "crates/utils",
+    "crates/history",
 ]

--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "gloo-history"
+version = "0.1.0"
+description = "Universal Session History"
+authors = ["Rust and WebAssembly Working Group"]
+edition = "2018"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/rustwasm/gloo/tree/master/crates/history"
+homepage = "https://github.com/rustwasm/gloo"
+categories = ["api-bindings", "storage", "wasm"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+gloo-utils = { version = "0.1.0", path = "../utils" }
+gloo-events = { version = "0.1.0", path = "../events" }
+serde = "1"
+serde_urlencoded = "0.7"
+serde-wasm-bindgen = "0.3.1"
+thiserror = "1.0"
+
+[dependencies.web-sys]
+version = "0.3"
+features = [
+    # "Attr",
+    # "Document",
+    "History",
+    # "HtmlBaseElement",
+    # "Event",
+    # "NamedNodeMap",
+    # "Url",
+    # "UrlSearchParams",
+    "Window",
+]
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"
+serde = { version = "1", features = ["derive"] }
+
+# [dev-dependencies.web-sys]
+# version = "0.3"
+# features = [
+#     "HtmlHeadElement",
+# ]

--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -22,23 +22,12 @@ thiserror = "1.0"
 [dependencies.web-sys]
 version = "0.3"
 features = [
-    # "Attr",
-    # "Document",
     "History",
-    # "HtmlBaseElement",
-    # "Event",
-    # "NamedNodeMap",
-    # "Url",
-    # "UrlSearchParams",
     "Window",
+    "Location",
 ]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 serde = { version = "1", features = ["derive"] }
-
-# [dev-dependencies.web-sys]
-# version = "0.3"
-# features = [
-#     "HtmlHeadElement",
-# ]
+gloo-timers = { version = "0.2.0", features = ["futures"], path = "../timers" }

--- a/crates/history/src/any.rs
+++ b/crates/history/src/any.rs
@@ -126,9 +126,9 @@ impl History for AnyHistory {
 impl Location for AnyLocation {
     type History = AnyHistory;
 
-    fn pathname(&self) -> String {
+    fn path(&self) -> String {
         let Self::Browser(self_) = self;
-        self_.pathname()
+        self_.path()
     }
 
     fn search(&self) -> String {

--- a/crates/history/src/any.rs
+++ b/crates/history/src/any.rs
@@ -113,14 +113,6 @@ impl History for AnyHistory {
         let Self::Browser(self_) = self;
         AnyLocation::Browser(self_.location())
     }
-
-    fn state<T>(&self) -> HistoryResult<T>
-    where
-        T: DeserializeOwned + 'static,
-    {
-        let Self::Browser(self_) = self;
-        self_.state()
-    }
 }
 
 impl Location for AnyLocation {
@@ -147,6 +139,14 @@ impl Location for AnyLocation {
     fn hash(&self) -> String {
         let Self::Browser(self_) = self;
         self_.hash()
+    }
+
+    fn state<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        let Self::Browser(self_) = self;
+        self_.state()
     }
 }
 

--- a/crates/history/src/any.rs
+++ b/crates/history/src/any.rs
@@ -1,0 +1,163 @@
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::browser::{BrowserHistory, BrowserLocation};
+use crate::error::HistoryResult;
+use crate::history::History;
+use crate::listener::HistoryListener;
+use crate::location::Location;
+
+/// A [`History`] that is always available under a [`Router`](crate::Router).
+#[derive(Clone, PartialEq)]
+pub enum AnyHistory {
+    Browser(BrowserHistory),
+}
+
+/// The [`Location`] for [`AnyHistory`]
+#[derive(Clone, PartialEq)]
+pub enum AnyLocation {
+    Browser(BrowserLocation),
+}
+
+impl History for AnyHistory {
+    type Location = AnyLocation;
+
+    fn len(&self) -> usize {
+        let Self::Browser(self_) = self;
+        self_.len()
+    }
+
+    fn go(&self, delta: isize) {
+        let Self::Browser(self_) = self;
+        self_.go(delta)
+    }
+
+    fn push(&self, route: impl Into<String>) {
+        let Self::Browser(self_) = self;
+        self_.push(route)
+    }
+
+    fn replace(&self, route: impl Into<String>) {
+        let Self::Browser(self_) = self;
+        self_.replace(route)
+    }
+
+    fn push_with_state<T>(&self, route: impl Into<String>, state: T) -> HistoryResult<()>
+    where
+        T: Serialize + 'static,
+    {
+        let Self::Browser(self_) = self;
+        self_.push_with_state(route, state)
+    }
+
+    fn replace_with_state<T>(&self, route: impl Into<String>, state: T) -> HistoryResult<()>
+    where
+        T: Serialize + 'static,
+    {
+        let Self::Browser(self_) = self;
+        self_.replace_with_state(route, state)
+    }
+
+    fn push_with_query<Q>(&self, route: impl Into<String>, query: Q) -> HistoryResult<()>
+    where
+        Q: Serialize,
+    {
+        let Self::Browser(self_) = self;
+        self_.push_with_query(route, query)
+    }
+    fn replace_with_query<Q>(&self, route: impl Into<String>, query: Q) -> HistoryResult<()>
+    where
+        Q: Serialize,
+    {
+        let Self::Browser(self_) = self;
+        self_.replace_with_query(route, query)
+    }
+
+    fn push_with_query_and_state<Q, T>(
+        &self,
+        route: impl Into<String>,
+        query: Q,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+        T: Serialize + 'static,
+    {
+        let Self::Browser(self_) = self;
+        self_.push_with_query_and_state(route, query, state)
+    }
+
+    fn replace_with_query_and_state<Q, T>(
+        &self,
+        route: impl Into<String>,
+        query: Q,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+        T: Serialize + 'static,
+    {
+        let Self::Browser(self_) = self;
+        self_.replace_with_query_and_state(route, query, state)
+    }
+
+    fn listen<CB>(&self, callback: CB) -> HistoryListener
+    where
+        CB: Fn() + 'static,
+    {
+        let Self::Browser(self_) = self;
+        self_.listen(callback)
+    }
+
+    fn location(&self) -> Self::Location {
+        let Self::Browser(self_) = self;
+        AnyLocation::Browser(self_.location())
+    }
+
+    fn state<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        let Self::Browser(self_) = self;
+        self_.state()
+    }
+}
+
+impl Location for AnyLocation {
+    type History = AnyHistory;
+
+    fn pathname(&self) -> String {
+        let Self::Browser(self_) = self;
+        self_.pathname()
+    }
+
+    fn search(&self) -> String {
+        let Self::Browser(self_) = self;
+        self_.search()
+    }
+
+    fn query<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let Self::Browser(self_) = self;
+        self_.query()
+    }
+
+    fn hash(&self) -> String {
+        let Self::Browser(self_) = self;
+        self_.hash()
+    }
+}
+
+impl From<BrowserHistory> for AnyHistory {
+    fn from(m: BrowserHistory) -> AnyHistory {
+        AnyHistory::Browser(m)
+    }
+}
+
+impl From<BrowserLocation> for AnyLocation {
+    fn from(m: BrowserLocation) -> AnyLocation {
+        AnyLocation::Browser(m)
+    }
+}

--- a/crates/history/src/browser.rs
+++ b/crates/history/src/browser.rs
@@ -1,0 +1,345 @@
+use std::cell::RefCell;
+use std::rc::{Rc, Weak};
+
+use gloo_events::EventListener;
+use gloo_utils::window;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use wasm_bindgen::{JsValue, UnwrapThrowExt};
+
+use crate::error::HistoryResult;
+use crate::history::History;
+use crate::listener::HistoryListener;
+use crate::location::Location;
+
+type WeakCallback = Weak<dyn Fn()>;
+
+/// A [`History`] that is implemented with [`web_sys::History`] that provides native browser
+/// history and state access.
+#[derive(Clone)]
+pub struct BrowserHistory {
+    inner: web_sys::History,
+    callbacks: Rc<RefCell<Vec<WeakCallback>>>,
+}
+
+impl PartialEq for BrowserHistory {
+    fn eq(&self, _rhs: &Self) -> bool {
+        // All browser histories are created equal.
+        true
+    }
+}
+
+impl History for BrowserHistory {
+    type Location = BrowserLocation;
+
+    fn len(&self) -> usize {
+        self.inner.length().expect_throw("failed to get length.") as usize
+    }
+
+    fn go(&self, delta: isize) {
+        self.inner
+            .go_with_delta(delta as i32)
+            .expect_throw("failed to call go.")
+    }
+
+    fn push(&self, route: impl Into<String>) {
+        let url = route.into();
+        self.inner
+            .push_state_with_url(&JsValue::NULL, "", Some(&url))
+            .expect("failed to push state.");
+
+        self.notify_callbacks();
+    }
+
+    fn replace(&self, route: impl Into<String>) {
+        let url = route.into();
+        self.inner
+            .replace_state_with_url(&JsValue::NULL, "", Some(&url))
+            .expect("failed to replace history.");
+
+        self.notify_callbacks();
+    }
+
+    fn push_with_state<T>(&self, route: impl Into<String>, state: T) -> HistoryResult<()>
+    where
+        T: Serialize + 'static,
+    {
+        let url = route.into();
+        let state = serde_wasm_bindgen::to_value(&state)?;
+        self.inner
+            .push_state_with_url(&state, "", Some(&url))
+            .expect("failed to push state.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    fn replace_with_state<T>(&self, route: impl Into<String>, state: T) -> HistoryResult<()>
+    where
+        T: Serialize + 'static,
+    {
+        let url = route.into();
+        let state = serde_wasm_bindgen::to_value(&state)?;
+        self.inner
+            .replace_state_with_url(&state, "", Some(&url))
+            .expect("failed to replace state.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    fn push_with_query<Q>(&self, route: impl Into<String>, query: Q) -> HistoryResult<()>
+    where
+        Q: Serialize,
+    {
+        let url = route.into();
+        let query = serde_urlencoded::to_string(query)?;
+        self.inner
+            .push_state_with_url(&JsValue::NULL, "", Some(&format!("{}?{}", url, query)))
+            .expect("failed to push history.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+    fn replace_with_query<Q>(&self, route: impl Into<String>, query: Q) -> HistoryResult<()>
+    where
+        Q: Serialize,
+    {
+        let url = route.into();
+        let query = serde_urlencoded::to_string(query)?;
+        self.inner
+            .replace_state_with_url(&JsValue::NULL, "", Some(&format!("{}?{}", url, query)))
+            .expect("failed to replace history.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    fn push_with_query_and_state<Q, T>(
+        &self,
+        route: impl Into<String>,
+        query: Q,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+        T: Serialize + 'static,
+    {
+        let url = route.into();
+        let query = serde_urlencoded::to_string(query)?;
+        let state = serde_wasm_bindgen::to_value(&state)?;
+        self.inner
+            .push_state_with_url(&state, "", Some(&format!("{}?{}", url, query)))
+            .expect("failed to push history.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    fn replace_with_query_and_state<Q, T>(
+        &self,
+        route: impl Into<String>,
+        query: Q,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+        T: Serialize + 'static,
+    {
+        let url = route.into();
+        let query = serde_urlencoded::to_string(query)?;
+        let state = serde_wasm_bindgen::to_value(&state)?;
+        self.inner
+            .replace_state_with_url(&state, "", Some(&format!("{}?{}", url, query)))
+            .expect("failed to replace history.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    fn listen<CB>(&self, callback: CB) -> HistoryListener
+    where
+        CB: Fn() + 'static,
+    {
+        // Callbacks do not receive a copy of [`History`] to prevent reference cycle.
+        let cb = Rc::new(callback) as Rc<dyn Fn()>;
+
+        self.callbacks.borrow_mut().push(Rc::downgrade(&cb));
+
+        HistoryListener { _listener: cb }
+    }
+
+    fn location(&self) -> Self::Location {
+        BrowserLocation::new(self.clone())
+    }
+
+    fn state<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        serde_wasm_bindgen::from_value(self.inner.state().expect_throw("failed to read state."))
+            .map_err(|e| e.into())
+    }
+}
+
+impl Default for BrowserHistory {
+    fn default() -> Self {
+        // We create browser history only once.
+        thread_local! {
+            static BROWSER_HISTORY: RefCell<Option<BrowserHistory>> = RefCell::default();
+            static LISTENER: RefCell<Option<EventListener>> = RefCell::default();
+        }
+
+        BROWSER_HISTORY.with(|m| {
+            let mut m = m.borrow_mut();
+
+            let history = match *m {
+                Some(ref m) => m.clone(),
+                None => {
+                    let window = window();
+
+                    let inner = window
+                        .history()
+                        .expect_throw("Failed to create browser history. Are you using a browser?");
+                    let callbacks = Rc::default();
+
+                    let history = Self { inner, callbacks };
+
+                    let history_clone = history.clone();
+
+                    // Listens to popstate.
+                    LISTENER.with(move |m| {
+                        let mut listener = m.borrow_mut();
+
+                        *listener = Some(EventListener::new(&window, "popstate", move |_| {
+                            history_clone.notify_callbacks();
+                        }));
+                    });
+
+                    history
+                }
+            };
+
+            *m = Some(history.clone());
+
+            history
+        })
+    }
+}
+
+impl BrowserHistory {
+    /// Creates a new [`BrowserHistory`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn notify_callbacks(&self) {
+        let callables = {
+            let mut callbacks_ref = self.callbacks.borrow_mut();
+
+            // Any gone weak references are removed when called.
+            let (callbacks, callbacks_weak) = callbacks_ref.iter().cloned().fold(
+                (Vec::new(), Vec::new()),
+                |(mut callbacks, mut callbacks_weak), m| {
+                    if let Some(m_strong) = m.clone().upgrade() {
+                        callbacks.push(m_strong);
+                        callbacks_weak.push(m);
+                    }
+
+                    (callbacks, callbacks_weak)
+                },
+            );
+
+            *callbacks_ref = callbacks_weak;
+
+            callbacks
+        };
+
+        for callback in callables {
+            callback()
+        }
+    }
+}
+
+/// The [`Location`] type for [`BrowserHistory`].
+///
+/// Most functionality of this type is provided by [`web_sys::Location`].
+///
+/// This type also provides additional methods that are unique to Browsers and are not available in [`Location`].
+///
+/// This types is read-only as most setters on `window.location` would cause a reload.
+#[derive(Clone)]
+pub struct BrowserLocation {
+    inner: web_sys::Location,
+    _history: BrowserHistory,
+}
+
+impl PartialEq for BrowserLocation {
+    fn eq(&self, rhs: &Self) -> bool {
+        self._history == rhs._history
+    }
+}
+
+impl Location for BrowserLocation {
+    type History = BrowserHistory;
+
+    fn pathname(&self) -> String {
+        self.inner
+            .pathname()
+            .expect_throw("failed to get pathname.")
+    }
+
+    fn search(&self) -> String {
+        self.inner.search().expect_throw("failed to get search.")
+    }
+
+    fn query<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let query = self.search();
+        serde_urlencoded::from_str(query.strip_prefix('?').unwrap_or("")).map_err(|e| e.into())
+    }
+
+    fn hash(&self) -> String {
+        self.inner.hash().expect_throw("failed to get hash.")
+    }
+}
+
+impl BrowserLocation {
+    fn new(history: BrowserHistory) -> Self {
+        Self {
+            inner: window().location(),
+            _history: history,
+        }
+    }
+
+    /// Returns the `href` of current [`Location`].
+    pub fn href(&self) -> String {
+        self.inner.href().expect_throw("failed to get href.")
+    }
+
+    /// Returns the `origin` of current [`Location`].
+    pub fn origin(&self) -> String {
+        self.inner.origin().expect_throw("failed to get origin.")
+    }
+
+    /// Returns the `protocol` property of current [`Location`].
+    pub fn protocol(&self) -> String {
+        self.inner
+            .protocol()
+            .expect_throw("failed to get protocol.")
+    }
+
+    /// Returns the `host` of current [`Location`].
+    pub fn host(&self) -> String {
+        self.inner.host().expect_throw("failed to get host.")
+    }
+
+    /// Returns the `hostname` of current [`Location`].
+    pub fn hostname(&self) -> String {
+        self.inner
+            .hostname()
+            .expect_throw("failed to get hostname.")
+    }
+}

--- a/crates/history/src/browser.rs
+++ b/crates/history/src/browser.rs
@@ -172,14 +172,6 @@ impl History for BrowserHistory {
     fn location(&self) -> Self::Location {
         BrowserLocation::new(self.clone())
     }
-
-    fn state<T>(&self) -> HistoryResult<T>
-    where
-        T: DeserializeOwned + 'static,
-    {
-        serde_wasm_bindgen::from_value(self.inner.state().expect_throw("failed to read state."))
-            .map_err(|e| e.into())
-    }
 }
 
 impl Default for BrowserHistory {
@@ -271,12 +263,12 @@ impl BrowserHistory {
 #[derive(Clone)]
 pub struct BrowserLocation {
     inner: web_sys::Location,
-    _history: BrowserHistory,
+    history: BrowserHistory,
 }
 
 impl PartialEq for BrowserLocation {
     fn eq(&self, rhs: &Self) -> bool {
-        self._history == rhs._history
+        self.history == rhs.history
     }
 }
 
@@ -304,13 +296,26 @@ impl Location for BrowserLocation {
     fn hash(&self) -> String {
         self.inner.hash().expect_throw("failed to get hash.")
     }
+
+    fn state<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        serde_wasm_bindgen::from_value(
+            self.history
+                .inner
+                .state()
+                .expect_throw("failed to read state."),
+        )
+        .map_err(|e| e.into())
+    }
 }
 
 impl BrowserLocation {
     fn new(history: BrowserHistory) -> Self {
         Self {
             inner: window().location(),
-            _history: history,
+            history,
         }
     }
 

--- a/crates/history/src/browser.rs
+++ b/crates/history/src/browser.rs
@@ -283,7 +283,7 @@ impl PartialEq for BrowserLocation {
 impl Location for BrowserLocation {
     type History = BrowserHistory;
 
-    fn pathname(&self) -> String {
+    fn path(&self) -> String {
         self.inner
             .pathname()
             .expect_throw("failed to get pathname.")

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum HistoryError {
+    #[error("failed to serialize / deserialize state.")]
+    State(#[from] serde_wasm_bindgen::Error),
+    #[error("failed to serialize query.")]
+    QuerySer(#[from] serde_urlencoded::ser::Error),
+    #[error("failed to deserialize query.")]
+    QueryDe(#[from] serde_urlencoded::de::Error),
+}
+
+pub type HistoryResult<T> = std::result::Result<T, HistoryError>;

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -1,3 +1,4 @@
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::error::HistoryResult;
@@ -106,5 +107,7 @@ pub trait History: Clone + PartialEq {
     ///
     /// For [`BrowserHistory`] and [`HashHistory`], state is serialised with [`serde_wasm_bindgen`] where as
     /// [`MemoryHistory`] uses [`Any`](std::any::Any).
-    fn state<T>(&self) -> HistoryResult<T>;
+    fn state<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned + 'static;
 }

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -1,4 +1,3 @@
-use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use crate::error::HistoryResult;

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -100,14 +100,4 @@ pub trait History: Clone + PartialEq {
 
     /// Returns the associated [`Location`] of the current history.
     fn location(&self) -> Self::Location;
-
-    /// Returns the State.
-    ///
-    /// The implementation differs between [`History`] type.
-    ///
-    /// For [`BrowserHistory`] and [`HashHistory`], state is serialised with [`serde_wasm_bindgen`] where as
-    /// [`MemoryHistory`] uses [`Any`](std::any::Any).
-    fn state<T>(&self) -> HistoryResult<T>
-    where
-        T: DeserializeOwned + 'static;
 }

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -1,0 +1,110 @@
+use serde::Serialize;
+
+use crate::error::HistoryResult;
+use crate::listener::HistoryListener;
+use crate::location::Location;
+
+/// A trait to provide [`History`] access.
+pub trait History: Clone + PartialEq {
+    type Location: Location<History = Self> + 'static;
+
+    /// Returns the number of elements in [`History`].
+    fn len(&self) -> usize;
+
+    /// Returns true if the current [`History`] is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Moves back 1 page in [`History`].
+    fn back(&self) {
+        self.go(-1);
+    }
+
+    /// Moves forward 1 page in [`History`].
+    fn forward(&self) {
+        self.go(1);
+    }
+
+    /// Loads a specific page in [`History`] with a `delta` relative to current page.
+    ///
+    /// See: <https://developer.mozilla.org/en-US/docs/Web/API/History/go>
+    fn go(&self, delta: isize);
+
+    /// Pushes a route entry with [`None`] being the state.
+    fn push(&self, route: impl Into<String>);
+
+    /// Replaces the current history entry with provided route and [`None`] state.
+    fn replace(&self, route: impl Into<String>);
+
+    /// Pushes a route entry with state.
+    ///
+    /// The implementation of state serialization differs between [`History`] types.
+    ///
+    /// For [`BrowserHistory`] and [`HashHistory`], state is serialised with [`serde_wasm_bindgen`] where as
+    /// [`MemoryHistory`] uses [`Any`](std::any::Any).
+    fn push_with_state<T>(&self, route: impl Into<String>, state: T) -> HistoryResult<()>
+    where
+        T: Serialize + 'static;
+
+    /// Replaces the current history entry with provided route and state.
+    ///
+    /// The implementation of state serialization differs between [`History`] types.
+    ///
+    /// For [`BrowserHistory`], it uses [`serde_wasm_bindgen`] where as other types uses
+    /// [`Any`](std::any::Any).
+    fn replace_with_state<T>(&self, route: impl Into<String>, state: T) -> HistoryResult<()>
+    where
+        T: Serialize + 'static;
+
+    /// Same as `.push()` but affix the queries to the end of the route.
+    fn push_with_query<Q>(&self, route: impl Into<String>, query: Q) -> HistoryResult<()>
+    where
+        Q: Serialize;
+
+    /// Same as `.replace()` but affix the queries to the end of the route.
+    fn replace_with_query<Q>(&self, route: impl Into<String>, query: Q) -> HistoryResult<()>
+    where
+        Q: Serialize;
+
+    /// Same as `.push_with_state()` but affix the queries to the end of the route.
+    fn push_with_query_and_state<Q, T>(
+        &self,
+        route: impl Into<String>,
+        query: Q,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+        T: Serialize + 'static;
+
+    /// Same as `.replace_with_state()` but affix the queries to the end of the route.
+    fn replace_with_query_and_state<Q, T>(
+        &self,
+        route: impl Into<String>,
+        query: Q,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+        T: Serialize + 'static;
+
+    /// Creates a Listener that will be notified when current state changes.
+    ///
+    /// This method returns a [`HistoryListener`] that will automatically unregister the callback
+    /// when dropped.
+    fn listen<CB>(&self, callback: CB) -> HistoryListener
+    where
+        CB: Fn() + 'static;
+
+    /// Returns the associated [`Location`] of the current history.
+    fn location(&self) -> Self::Location;
+
+    /// Returns the State.
+    ///
+    /// The implementation differs between [`History`] type.
+    ///
+    /// For [`BrowserHistory`] and [`HashHistory`], state is serialised with [`serde_wasm_bindgen`] where as
+    /// [`MemoryHistory`] uses [`Any`](std::any::Any).
+    fn state<T>(&self) -> HistoryResult<T>;
+}

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -1,0 +1,21 @@
+//! A module that provides universal session history and location information.
+
+// use std::borrow::Cow;
+// use std::cell::RefCell;
+// use std::rc::Rc;
+
+// use gloo_events::EventListener;
+// use gloo_utils::window;
+// use serde::de::DeserializeOwned;
+// use serde::Serialize;
+// use wasm_bindgen::{JsValue, UnwrapThrowExt};
+
+mod error;
+mod history;
+mod listener;
+mod location;
+
+pub use error::{HistoryError, HistoryResult};
+pub use history::History;
+pub use listener::HistoryListener;
+pub use location::Location;

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -1,20 +1,14 @@
 //! A module that provides universal session history and location information.
 
-// use std::borrow::Cow;
-// use std::cell::RefCell;
-// use std::rc::Rc;
-
-// use gloo_events::EventListener;
-// use gloo_utils::window;
-// use serde::de::DeserializeOwned;
-// use serde::Serialize;
-// use wasm_bindgen::{JsValue, UnwrapThrowExt};
-
+mod any;
+mod browser;
 mod error;
 mod history;
 mod listener;
 mod location;
 
+pub use any::{AnyHistory, AnyLocation};
+pub use browser::{BrowserHistory, BrowserLocation};
 pub use error::{HistoryError, HistoryResult};
 pub use history::History;
 pub use listener::HistoryListener;

--- a/crates/history/src/listener.rs
+++ b/crates/history/src/listener.rs
@@ -1,0 +1,9 @@
+use std::rc::Rc;
+
+/// A History Listener to manage callbacks registered on a [`History`].
+///
+/// This Listener has the same behaviour as the [`EventListener`] from [`gloo`]
+/// that the underlying callback will be unregistered when the listener is dropped.
+pub struct HistoryListener {
+    _listener: Rc<dyn Fn()>,
+}

--- a/crates/history/src/listener.rs
+++ b/crates/history/src/listener.rs
@@ -5,5 +5,5 @@ use std::rc::Rc;
 /// This Listener has the same behaviour as the [`EventListener`] from [`gloo`]
 /// that the underlying callback will be unregistered when the listener is dropped.
 pub struct HistoryListener {
-    _listener: Rc<dyn Fn()>,
+    pub(crate) _listener: Rc<dyn Fn()>,
 }

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -8,7 +8,7 @@ pub trait Location: Clone + PartialEq {
     type History: History<Location = Self> + 'static;
 
     /// Returns the `pathname` on the [`Location`] struct.
-    fn pathname(&self) -> String;
+    fn path(&self) -> String;
 
     /// Returns the queries of current URL in [`String`]
     fn search(&self) -> String;

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -20,4 +20,14 @@ pub trait Location: Clone + PartialEq {
 
     /// Returns the hash fragment of current URL.
     fn hash(&self) -> String;
+
+    /// Returns the State.
+    ///
+    /// The implementation differs between [`History`] type.
+    ///
+    /// For [`BrowserHistory`] and [`HashHistory`], state is serialised with [`serde_wasm_bindgen`] where as
+    /// [`MemoryHistory`] uses [`Any`](std::any::Any).
+    fn state<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned + 'static;
 }

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -1,0 +1,23 @@
+use serde::de::DeserializeOwned;
+
+use crate::error::HistoryResult;
+use crate::history::History;
+
+/// A trait to to provide [`Location`] information.
+pub trait Location: Clone + PartialEq {
+    type History: History<Location = Self> + 'static;
+
+    /// Returns the `pathname` on the [`Location`] struct.
+    fn pathname(&self) -> String;
+
+    /// Returns the queries of current URL in [`String`]
+    fn search(&self) -> String;
+
+    /// Returns the queries of current URL parsed as `T`.
+    fn query<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned;
+
+    /// Returns the hash fragment of current URL.
+    fn hash(&self) -> String;
+}

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -23,10 +23,10 @@ pub trait Location: Clone + PartialEq {
 
     /// Returns the State.
     ///
-    /// The implementation differs between [`History`] type.
+    /// The implementation differs between [`Location`] type.
     ///
-    /// For [`BrowserHistory`] and [`HashHistory`], state is serialised with [`serde_wasm_bindgen`] where as
-    /// [`MemoryHistory`] uses [`Any`](std::any::Any).
+    /// For [`BrowserLocation`] and [`HashLocation`], state is deserialised with [`serde_wasm_bindgen`] where as
+    /// [`MemoryLocation`] uses [`Any`](std::any::Any).
     fn state<T>(&self) -> HistoryResult<T>
     where
         T: DeserializeOwned + 'static;

--- a/crates/history/tests/browser_history.rs
+++ b/crates/history/tests/browser_history.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+
+use gloo_timers::future::sleep;
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+use serde::{Deserialize, Serialize};
+
+use gloo_history::{BrowserHistory, History, Location};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct Query {
+    a: String,
+    b: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct State {
+    i: String,
+    ii: u64,
+}
+
+#[test]
+async fn history_works() {
+    let history = BrowserHistory::new();
+    assert_eq!(history.location().path(), "/");
+
+    history.push("/path-a");
+    assert_eq!(history.location().path(), "/path-a");
+
+    history.replace("/path-b");
+    assert_eq!(history.location().path(), "/path-b");
+
+    history.back();
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(history.location().path(), "/");
+
+    history.forward();
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(history.location().path(), "/path-b");
+
+    history
+        .push_with_query(
+            "/path",
+            Query {
+                a: "something".to_string(),
+                b: 123,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(history.location().path(), "/path");
+    assert_eq!(history.location().search(), "?a=something&b=123");
+    assert_eq!(
+        history.location().query::<Query>().unwrap(),
+        Query {
+            a: "something".to_string(),
+            b: 123,
+        }
+    );
+
+    history
+        .push_with_state(
+            "/path-c",
+            State {
+                i: "something".to_string(),
+                ii: 123,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(history.location().path(), "/path-c");
+    assert_eq!(
+        history.location().state::<State>().unwrap(),
+        State {
+            i: "something".to_string(),
+            ii: 123,
+        }
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub use gloo_console as console;
 pub use gloo_dialogs as dialogs;
 pub use gloo_events as events;
 pub use gloo_file as file;
+pub use gloo_history as history;
 pub use gloo_render as render;
 pub use gloo_storage as storage;
 pub use gloo_timers as timers;

--- a/website/docs/history/intro.md
+++ b/website/docs/history/intro.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 1
+title: Introduction
+slug: /history
+---
+
+A crate that provides universal session histroy API in both browser and
+non-browser environment.
+
+See the API docs to learn more.


### PR DESCRIPTION
The PR adds the initial `BrowserHistory` and `BrowserLocation` that was initially implemented for `yew-router`.

Comparing to `yew-router`'s implementation, it strips the following features:
- typed routes.
- base name handling.

### History leaking
(a.k.a: sometimes it's possible to cause the page to reload, or navigate away from the SPA with certain methods like `history.go(0)`)

After some consideration, I think it ultimately does not matter too much and is kind of hard to prevent.

- `history.go(0)` is equivalent to `location.reload()`.
   Which means the user should know what they are doing when they are calling this method with 0.
- `history.back()` or `history.go(-1)` (or `history.forward()` and `history.go(1)`)
   If the last state is created by `history.pushState`, then a `popstate` event will be fired.
   If the last state is on another page, then user will be navigated back to the last page.
   If this is the first state in the history queue, then nothing happens.
   In addition, there's no way to "peek" the next history which means we cannot really know what would happen unless it really happens.

JavaScript version of `history` does not patch / trying to prevent this either:

https://github.com/remix-run/history/blob/main/packages/history/index.ts#L521