### PR TITLE
Fixes `console_dbg!` and `console!` expression output. Bold src info.

### DIFF
--- a/crates/console/src/console_dbg.rs
+++ b/crates/console/src/console_dbg.rs
@@ -8,7 +8,7 @@ macro_rules! console {
     () => {
         $crate::log!(
             ::std::format!("%c[{}:{}] ", ::std::file!(), ::std::line!()),
-            "font-weight: bold",
+            "font-weight: bold"
         );
     };
     ($val:expr $(,)?) => {


### PR DESCRIPTION
```rust
    let a = 1;
    gloo_console::console_dbg!("123", a, a + 1);
    gloo_console::console_dbg!(String::from("123"));
    gloo_console::console!(b());

    let b: JsString = "123".into();
    gloo_console::console!(b);

    gloo_console::console!({let c: JsString = "cc".into(); c});
```

![image](https://user-images.githubusercontent.com/44753941/143574872-5c4c97fa-d2aa-4398-b9c2-2ad01604a884.png)

