### PR TITLE
Hash-based History type & Unified Location.

### DIFF
--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -39,10 +39,7 @@ pub mod __macro {
         columns: impl IntoIterator<Item = &'a str>,
     ) {
         let data = JsValue::from_serde(&data).unwrap_throw();
-        let columns = columns
-            .into_iter()
-            .map(|it| JsValue::from_str(it))
-            .collect();
+        let columns = columns.into_iter().map(JsValue::from_str).collect();
 
         crate::externs::table_with_data_and_columns(data, columns);
     }

--- a/crates/file/src/file_reader.rs
+++ b/crates/file/src/file_reader.rs
@@ -14,8 +14,8 @@ pub mod callbacks {
     #[derive(Debug)]
     pub struct FileReader {
         reader: web_sys::FileReader,
-        load_listener: EventListener,
-        error_listener: EventListener,
+        _load_listener: EventListener,
+        _error_listener: EventListener,
     }
 
     impl std::ops::Drop for FileReader {
@@ -135,8 +135,8 @@ pub mod callbacks {
 
         FileReader {
             reader,
-            load_listener,
-            error_listener,
+            _load_listener: load_listener,
+            _error_listener: error_listener,
         }
     }
 }

--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -25,6 +25,7 @@ features = [
     "History",
     "Window",
     "Location",
+    "Url",
 ]
 
 [dev-dependencies]

--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["api-bindings", "history", "wasm"]
 wasm-bindgen = "0.2"
 gloo-utils = { version = "0.1.0", path = "../utils" }
 gloo-events = { version = "0.1.0", path = "../events" }
-serde = { version = "1", optional = true }
+serde = "1"
+serde-wasm-bindgen = "0.3.1"
 serde_urlencoded = { version = "0.7", optional = true }
-serde-wasm-bindgen = { version = "0.3.1", optional = true }
 thiserror = { version = "1.0", optional = true }
 
 [dependencies.web-sys]
@@ -34,6 +34,5 @@ serde = { version = "1", features = ["derive"] }
 gloo-timers = { version = "0.2.0", features = ["futures"], path = "../timers" }
 
 [features]
-query = ["serde", "thiserror", "serde_urlencoded"]
-state = ["serde", "thiserror", "serde-wasm-bindgen"]
-default = ["query", "state"]
+query = ["thiserror", "serde_urlencoded"]
+default = ["query"]

--- a/crates/history/src/any.rs
+++ b/crates/history/src/any.rs
@@ -175,21 +175,10 @@ impl Location for AnyLocation {
         }
     }
 
-    fn search(&self) -> String {
+    fn query_str(&self) -> String {
         match self {
-            Self::Browser(m) => m.search(),
-            Self::Hash(m) => m.search(),
-        }
-    }
-
-    #[cfg(feature = "query")]
-    fn query<T>(&self) -> HistoryResult<T>
-    where
-        T: DeserializeOwned,
-    {
-        match self {
-            Self::Browser(m) => m.query(),
-            Self::Hash(m) => m.query(),
+            Self::Browser(m) => m.query_str(),
+            Self::Hash(m) => m.query_str(),
         }
     }
 

--- a/crates/history/src/any.rs
+++ b/crates/history/src/any.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use crate::browser::{BrowserHistory, BrowserLocation};
 #[cfg(feature = "serde")]
 use crate::error::HistoryResult;
+use crate::hash::{HashHistory, HashLocation};
 use crate::history::History;
 use crate::listener::HistoryListener;
 use crate::location::Location;
@@ -17,6 +18,8 @@ use crate::location::Location;
 pub enum AnyHistory {
     /// A Browser History.
     Browser(BrowserHistory),
+    /// A Hash History
+    Hash(HashHistory),
 }
 
 /// The [`Location`] for [`AnyHistory`]
@@ -24,6 +27,8 @@ pub enum AnyHistory {
 pub enum AnyLocation {
     /// A Browser Location.
     Browser(BrowserLocation),
+    /// A Hash Location.
+    Hash(HashLocation),
 }
 
 impl History for AnyHistory {
@@ -32,24 +37,28 @@ impl History for AnyHistory {
     fn len(&self) -> usize {
         match self {
             Self::Browser(m) => m.len(),
+            Self::Hash(m) => m.len(),
         }
     }
 
     fn go(&self, delta: isize) {
         match self {
             Self::Browser(m) => m.go(delta),
+            Self::Hash(m) => m.go(delta),
         }
     }
 
     fn push<'a>(&self, route: impl Into<Cow<'a, str>>) {
         match self {
             Self::Browser(m) => m.push(route),
+            Self::Hash(m) => m.push(route),
         }
     }
 
     fn replace<'a>(&self, route: impl Into<Cow<'a, str>>) {
         match self {
             Self::Browser(m) => m.replace(route),
+            Self::Hash(m) => m.replace(route),
         }
     }
 
@@ -60,6 +69,7 @@ impl History for AnyHistory {
     {
         match self {
             Self::Browser(m) => m.push_with_state(route, state),
+            Self::Hash(m) => m.push_with_state(route, state),
         }
     }
 
@@ -74,6 +84,7 @@ impl History for AnyHistory {
     {
         match self {
             Self::Browser(m) => m.replace_with_state(route, state),
+            Self::Hash(m) => m.replace_with_state(route, state),
         }
     }
 
@@ -84,6 +95,7 @@ impl History for AnyHistory {
     {
         match self {
             Self::Browser(m) => m.push_with_query(route, query),
+            Self::Hash(m) => m.push_with_query(route, query),
         }
     }
     #[cfg(feature = "query")]
@@ -97,6 +109,7 @@ impl History for AnyHistory {
     {
         match self {
             Self::Browser(m) => m.replace_with_query(route, query),
+            Self::Hash(m) => m.replace_with_query(route, query),
         }
     }
 
@@ -113,6 +126,7 @@ impl History for AnyHistory {
     {
         match self {
             Self::Browser(m) => m.push_with_query_and_state(route, query, state),
+            Self::Hash(m) => m.push_with_query_and_state(route, query, state),
         }
     }
 
@@ -129,6 +143,7 @@ impl History for AnyHistory {
     {
         match self {
             Self::Browser(m) => m.replace_with_query_and_state(route, query, state),
+            Self::Hash(m) => m.replace_with_query_and_state(route, query, state),
         }
     }
 
@@ -138,12 +153,14 @@ impl History for AnyHistory {
     {
         match self {
             Self::Browser(m) => m.listen(callback),
+            Self::Hash(m) => m.listen(callback),
         }
     }
 
     fn location(&self) -> Self::Location {
         match self {
             Self::Browser(m) => AnyLocation::Browser(m.location()),
+            Self::Hash(m) => AnyLocation::Hash(m.location()),
         }
     }
 }
@@ -154,12 +171,14 @@ impl Location for AnyLocation {
     fn path(&self) -> String {
         match self {
             Self::Browser(m) => m.path(),
+            Self::Hash(m) => m.path(),
         }
     }
 
     fn search(&self) -> String {
         match self {
             Self::Browser(m) => m.search(),
+            Self::Hash(m) => m.search(),
         }
     }
 
@@ -170,12 +189,14 @@ impl Location for AnyLocation {
     {
         match self {
             Self::Browser(m) => m.query(),
+            Self::Hash(m) => m.query(),
         }
     }
 
     fn hash(&self) -> String {
         match self {
             Self::Browser(m) => m.hash(),
+            Self::Hash(m) => m.hash(),
         }
     }
 
@@ -186,6 +207,7 @@ impl Location for AnyLocation {
     {
         match self {
             Self::Browser(m) => m.state(),
+            Self::Hash(m) => m.state(),
         }
     }
 }
@@ -199,5 +221,17 @@ impl From<BrowserHistory> for AnyHistory {
 impl From<BrowserLocation> for AnyLocation {
     fn from(m: BrowserLocation) -> AnyLocation {
         AnyLocation::Browser(m)
+    }
+}
+
+impl From<HashHistory> for AnyHistory {
+    fn from(m: HashHistory) -> AnyHistory {
+        AnyHistory::Hash(m)
+    }
+}
+
+impl From<HashLocation> for AnyLocation {
+    fn from(m: HashLocation) -> AnyLocation {
+        AnyLocation::Hash(m)
     }
 }

--- a/crates/history/src/any.rs
+++ b/crates/history/src/any.rs
@@ -1,14 +1,12 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "serde")]
-use serde::de::DeserializeOwned;
-#[cfg(feature = "serde")]
+#[cfg(feature = "query")]
 use serde::Serialize;
 
-use crate::browser::{BrowserHistory, BrowserLocation};
-#[cfg(feature = "serde")]
+use crate::browser::BrowserHistory;
+#[cfg(feature = "query")]
 use crate::error::HistoryResult;
-use crate::hash::{HashHistory, HashLocation};
+use crate::hash::HashHistory;
 use crate::history::History;
 use crate::listener::HistoryListener;
 use crate::location::Location;
@@ -22,18 +20,7 @@ pub enum AnyHistory {
     Hash(HashHistory),
 }
 
-/// The [`Location`] for [`AnyHistory`]
-#[derive(Clone, PartialEq, Debug)]
-pub enum AnyLocation {
-    /// A Browser Location.
-    Browser(BrowserLocation),
-    /// A Hash Location.
-    Hash(HashLocation),
-}
-
 impl History for AnyHistory {
-    type Location = AnyLocation;
-
     fn len(&self) -> usize {
         match self {
             Self::Browser(m) => m.len(),
@@ -62,10 +49,9 @@ impl History for AnyHistory {
         }
     }
 
-    #[cfg(feature = "state")]
-    fn push_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T) -> HistoryResult<()>
+    fn push_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T)
     where
-        T: Serialize + 'static,
+        T: 'static,
     {
         match self {
             Self::Browser(m) => m.push_with_state(route, state),
@@ -73,14 +59,9 @@ impl History for AnyHistory {
         }
     }
 
-    #[cfg(feature = "state")]
-    fn replace_with_state<'a, T>(
-        &self,
-        route: impl Into<Cow<'a, str>>,
-        state: T,
-    ) -> HistoryResult<()>
+    fn replace_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T)
     where
-        T: Serialize + 'static,
+        T: 'static,
     {
         match self {
             Self::Browser(m) => m.replace_with_state(route, state),
@@ -113,7 +94,7 @@ impl History for AnyHistory {
         }
     }
 
-    #[cfg(all(feature = "query", feature = "state"))]
+    #[cfg(all(feature = "query"))]
     fn push_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -130,7 +111,7 @@ impl History for AnyHistory {
         }
     }
 
-    #[cfg(all(feature = "query", feature = "state"))]
+    #[cfg(all(feature = "query"))]
     fn replace_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -157,46 +138,10 @@ impl History for AnyHistory {
         }
     }
 
-    fn location(&self) -> Self::Location {
+    fn location(&self) -> Location {
         match self {
-            Self::Browser(m) => AnyLocation::Browser(m.location()),
-            Self::Hash(m) => AnyLocation::Hash(m.location()),
-        }
-    }
-}
-
-impl Location for AnyLocation {
-    type History = AnyHistory;
-
-    fn path(&self) -> String {
-        match self {
-            Self::Browser(m) => m.path(),
-            Self::Hash(m) => m.path(),
-        }
-    }
-
-    fn query_str(&self) -> String {
-        match self {
-            Self::Browser(m) => m.query_str(),
-            Self::Hash(m) => m.query_str(),
-        }
-    }
-
-    fn hash(&self) -> String {
-        match self {
-            Self::Browser(m) => m.hash(),
-            Self::Hash(m) => m.hash(),
-        }
-    }
-
-    #[cfg(feature = "state")]
-    fn state<T>(&self) -> HistoryResult<T>
-    where
-        T: DeserializeOwned + 'static,
-    {
-        match self {
-            Self::Browser(m) => m.state(),
-            Self::Hash(m) => m.state(),
+            Self::Browser(m) => m.location(),
+            Self::Hash(m) => m.location(),
         }
     }
 }
@@ -207,20 +152,8 @@ impl From<BrowserHistory> for AnyHistory {
     }
 }
 
-impl From<BrowserLocation> for AnyLocation {
-    fn from(m: BrowserLocation) -> AnyLocation {
-        AnyLocation::Browser(m)
-    }
-}
-
 impl From<HashHistory> for AnyHistory {
     fn from(m: HashHistory) -> AnyHistory {
         AnyHistory::Hash(m)
-    }
-}
-
-impl From<HashLocation> for AnyLocation {
-    fn from(m: HashLocation) -> AnyLocation {
-        AnyLocation::Hash(m)
     }
 }

--- a/crates/history/src/browser.rs
+++ b/crates/history/src/browser.rs
@@ -123,6 +123,7 @@ impl History for BrowserHistory {
         self.notify_callbacks();
         Ok(())
     }
+
     #[cfg(feature = "query")]
     fn replace_with_query<'a, Q>(
         &self,
@@ -247,7 +248,7 @@ impl Default for BrowserHistory {
         BROWSER_HISTORY.with(|m| {
             let mut m = m.borrow_mut();
 
-            let history = match *m {
+            match *m {
                 Some(ref m) => m.clone(),
                 None => {
                     let window = window();
@@ -276,13 +277,10 @@ impl Default for BrowserHistory {
                         });
                     }
 
+                    *m = Some(history.clone());
                     history
                 }
-            };
-
-            *m = Some(history.clone());
-
-            history
+            }
         })
     }
 }

--- a/crates/history/src/browser.rs
+++ b/crates/history/src/browser.rs
@@ -314,17 +314,8 @@ impl Location for BrowserLocation {
             .expect_throw("failed to get pathname.")
     }
 
-    fn search(&self) -> String {
+    fn query_str(&self) -> String {
         self.inner.search().expect_throw("failed to get search.")
-    }
-
-    #[cfg(feature = "query")]
-    fn query<T>(&self) -> HistoryResult<T>
-    where
-        T: DeserializeOwned,
-    {
-        let query = self.search();
-        serde_urlencoded::from_str(query.strip_prefix('?').unwrap_or("")).map_err(|e| e.into())
     }
 
     fn hash(&self) -> String {

--- a/crates/history/src/browser.rs
+++ b/crates/history/src/browser.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::borrow::Cow;
 use std::cell::RefCell;
 use std::fmt;
@@ -5,17 +6,16 @@ use std::rc::{Rc, Weak};
 
 use gloo_events::EventListener;
 use gloo_utils::window;
-#[cfg(feature = "serde")]
-use serde::de::DeserializeOwned;
-#[cfg(feature = "serde")]
+#[cfg(feature = "query")]
 use serde::Serialize;
 use wasm_bindgen::{JsValue, UnwrapThrowExt};
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "query")]
 use crate::error::HistoryResult;
 use crate::history::History;
 use crate::listener::HistoryListener;
 use crate::location::Location;
+use crate::state::{HistoryState, StateMap};
 
 type WeakCallback = Weak<dyn Fn()>;
 
@@ -24,6 +24,7 @@ type WeakCallback = Weak<dyn Fn()>;
 #[derive(Clone)]
 pub struct BrowserHistory {
     inner: web_sys::History,
+    states: Rc<RefCell<StateMap>>,
     callbacks: Rc<RefCell<Vec<WeakCallback>>>,
 }
 
@@ -41,8 +42,6 @@ impl PartialEq for BrowserHistory {
 }
 
 impl History for BrowserHistory {
-    type Location = BrowserLocation;
-
     fn len(&self) -> usize {
         self.inner.length().expect_throw("failed to get length.") as usize
     }
@@ -56,7 +55,7 @@ impl History for BrowserHistory {
     fn push<'a>(&self, route: impl Into<Cow<'a, str>>) {
         let url = route.into();
         self.inner
-            .push_state_with_url(&JsValue::NULL, "", Some(&url))
+            .push_state_with_url(&Self::create_history_state().1, "", Some(&url))
             .expect_throw("failed to push state.");
 
         self.notify_callbacks();
@@ -65,44 +64,45 @@ impl History for BrowserHistory {
     fn replace<'a>(&self, route: impl Into<Cow<'a, str>>) {
         let url = route.into();
         self.inner
-            .replace_state_with_url(&JsValue::NULL, "", Some(&url))
+            .replace_state_with_url(&Self::create_history_state().1, "", Some(&url))
             .expect_throw("failed to replace history.");
 
         self.notify_callbacks();
     }
 
-    #[cfg(feature = "state")]
-    fn push_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T) -> HistoryResult<()>
+    fn push_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T)
     where
-        T: Serialize + 'static,
+        T: 'static,
     {
         let url = route.into();
-        let state = serde_wasm_bindgen::to_value(&state)?;
+
+        let (id, history_state) = Self::create_history_state();
+
+        let mut states = self.states.borrow_mut();
+        states.insert(id, Rc::new(state) as Rc<dyn Any>);
+
         self.inner
-            .push_state_with_url(&state, "", Some(&url))
+            .push_state_with_url(&history_state, "", Some(&url))
             .expect_throw("failed to push state.");
 
         self.notify_callbacks();
-        Ok(())
     }
 
-    #[cfg(feature = "state")]
-    fn replace_with_state<'a, T>(
-        &self,
-        route: impl Into<Cow<'a, str>>,
-        state: T,
-    ) -> HistoryResult<()>
+    fn replace_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T)
     where
-        T: Serialize + 'static,
+        T: 'static,
     {
         let url = route.into();
-        let state = serde_wasm_bindgen::to_value(&state)?;
+
+        let (id, history_state) = Self::create_history_state();
+
+        let mut states = self.states.borrow_mut();
+        states.insert(id, Rc::new(state) as Rc<dyn Any>);
         self.inner
-            .replace_state_with_url(&state, "", Some(&url))
+            .replace_state_with_url(&history_state, "", Some(&url))
             .expect_throw("failed to replace state.");
 
         self.notify_callbacks();
-        Ok(())
     }
 
     #[cfg(feature = "query")]
@@ -113,7 +113,11 @@ impl History for BrowserHistory {
         let url = route.into();
         let query = serde_urlencoded::to_string(query)?;
         self.inner
-            .push_state_with_url(&JsValue::NULL, "", Some(&format!("{}?{}", url, query)))
+            .push_state_with_url(
+                &Self::create_history_state().1,
+                "",
+                Some(&format!("{}?{}", url, query)),
+            )
             .expect_throw("failed to push history.");
 
         self.notify_callbacks();
@@ -131,14 +135,18 @@ impl History for BrowserHistory {
         let url = route.into();
         let query = serde_urlencoded::to_string(query)?;
         self.inner
-            .replace_state_with_url(&JsValue::NULL, "", Some(&format!("{}?{}", url, query)))
+            .replace_state_with_url(
+                &Self::create_history_state().1,
+                "",
+                Some(&format!("{}?{}", url, query)),
+            )
             .expect_throw("failed to replace history.");
 
         self.notify_callbacks();
         Ok(())
     }
 
-    #[cfg(all(feature = "query", feature = "state"))]
+    #[cfg(all(feature = "query"))]
     fn push_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -147,20 +155,24 @@ impl History for BrowserHistory {
     ) -> HistoryResult<()>
     where
         Q: Serialize,
-        T: Serialize + 'static,
+        T: 'static,
     {
         let url = route.into();
         let query = serde_urlencoded::to_string(query)?;
-        let state = serde_wasm_bindgen::to_value(&state)?;
+
+        let (id, history_state) = Self::create_history_state();
+
+        let mut states = self.states.borrow_mut();
+        states.insert(id, Rc::new(state) as Rc<dyn Any>);
         self.inner
-            .push_state_with_url(&state, "", Some(&format!("{}?{}", url, query)))
+            .push_state_with_url(&history_state, "", Some(&format!("{}?{}", url, query)))
             .expect_throw("failed to push history.");
 
         self.notify_callbacks();
         Ok(())
     }
 
-    #[cfg(all(feature = "query", feature = "state"))]
+    #[cfg(all(feature = "query"))]
     fn replace_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -169,13 +181,17 @@ impl History for BrowserHistory {
     ) -> HistoryResult<()>
     where
         Q: Serialize,
-        T: Serialize + 'static,
+        T: 'static,
     {
         let url = route.into();
         let query = serde_urlencoded::to_string(query)?;
-        let state = serde_wasm_bindgen::to_value(&state)?;
+
+        let (id, history_state) = Self::create_history_state();
+
+        let mut states = self.states.borrow_mut();
+        states.insert(id, Rc::new(state) as Rc<dyn Any>);
         self.inner
-            .replace_state_with_url(&state, "", Some(&format!("{}?{}", url, query)))
+            .replace_state_with_url(&history_state, "", Some(&format!("{}?{}", url, query)))
             .expect_throw("failed to replace history.");
 
         self.notify_callbacks();
@@ -194,8 +210,29 @@ impl History for BrowserHistory {
         HistoryListener { _listener: cb }
     }
 
-    fn location(&self) -> Self::Location {
-        BrowserLocation::new(self.clone())
+    fn location(&self) -> Location {
+        let loc = window().location();
+
+        let history_state = self.inner.state().expect_throw("failed to get state");
+        let history_state = serde_wasm_bindgen::from_value::<HistoryState>(history_state).ok();
+
+        let id = history_state.map(|m| m.id());
+
+        let states = self.states.borrow();
+
+        Location {
+            path: loc.pathname().expect_throw("failed to get pathname").into(),
+            query_str: loc
+                .search()
+                .expect_throw("failed to get location query.")
+                .into(),
+            hash: loc
+                .hash()
+                .expect_throw("failed to get location hash.")
+                .into(),
+            state: id.and_then(|m| states.get(&m).cloned()),
+            id,
+        }
     }
 }
 
@@ -220,7 +257,11 @@ impl Default for BrowserHistory {
                         .expect_throw("Failed to create browser history. Are you using a browser?");
                     let callbacks = Rc::default();
 
-                    let history = Self { inner, callbacks };
+                    let history = Self {
+                        inner,
+                        callbacks,
+                        states: Rc::default(),
+                    };
 
                     {
                         let history = history.clone();
@@ -278,99 +319,14 @@ impl BrowserHistory {
             callback()
         }
     }
-}
 
-/// The [`Location`] type for [`BrowserHistory`].
-///
-/// Most functionality of this type is provided by [`web_sys::Location`].
-///
-/// This type also provides additional methods that are unique to Browsers and are not available in [`Location`].
-///
-/// This types is read-only as most setters on `window.location` would cause a reload.
-#[derive(Clone)]
-pub struct BrowserLocation {
-    inner: web_sys::Location,
-    history: BrowserHistory,
-}
+    fn create_history_state() -> (u32, JsValue) {
+        let history_state = HistoryState::new();
 
-impl fmt::Debug for BrowserLocation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("BrowserLocation").finish()
-    }
-}
-
-impl PartialEq for BrowserLocation {
-    fn eq(&self, rhs: &Self) -> bool {
-        self.history == rhs.history
-    }
-}
-
-impl Location for BrowserLocation {
-    type History = BrowserHistory;
-
-    fn path(&self) -> String {
-        self.inner
-            .pathname()
-            .expect_throw("failed to get pathname.")
-    }
-
-    fn query_str(&self) -> String {
-        self.inner.search().expect_throw("failed to get search.")
-    }
-
-    fn hash(&self) -> String {
-        self.inner.hash().expect_throw("failed to get hash.")
-    }
-
-    #[cfg(feature = "state")]
-    fn state<T>(&self) -> HistoryResult<T>
-    where
-        T: DeserializeOwned + 'static,
-    {
-        serde_wasm_bindgen::from_value(
-            self.history
-                .inner
-                .state()
-                .expect_throw("failed to read state."),
+        (
+            history_state.id(),
+            serde_wasm_bindgen::to_value(&history_state)
+                .expect_throw("fails to create history state."),
         )
-        .map_err(|e| e.into())
-    }
-}
-
-impl BrowserLocation {
-    fn new(history: BrowserHistory) -> Self {
-        Self {
-            inner: window().location(),
-            history,
-        }
-    }
-
-    /// Returns the `href` of current [`Location`].
-    pub fn href(&self) -> String {
-        self.inner.href().expect_throw("failed to get href.")
-    }
-
-    /// Returns the `origin` of current [`Location`].
-    pub fn origin(&self) -> String {
-        self.inner.origin().expect_throw("failed to get origin.")
-    }
-
-    /// Returns the `protocol` property of current [`Location`].
-    pub fn protocol(&self) -> String {
-        self.inner
-            .protocol()
-            .expect_throw("failed to get protocol.")
-    }
-
-    /// Returns the `host` of current [`Location`].
-    pub fn host(&self) -> String {
-        self.inner.host().expect_throw("failed to get host.")
-    }
-
-    /// Returns the `hostname` of current [`Location`].
-    pub fn hostname(&self) -> String {
-        self.inner
-            .hostname()
-            .expect_throw("failed to get hostname.")
     }
 }

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -3,10 +3,6 @@ use thiserror::Error;
 /// The Error type for History.
 #[derive(Error, Debug)]
 pub enum HistoryError {
-    /// Failed to serialize / deserialize state.
-    #[cfg(feature = "state")]
-    #[error("failed to serialize / deserialize state.")]
-    State(#[from] serde_wasm_bindgen::Error),
     /// Failed to serialize query.
     #[cfg(feature = "query")]
     #[error("failed to serialize query.")]

--- a/crates/history/src/hash.rs
+++ b/crates/history/src/hash.rs
@@ -1,0 +1,349 @@
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::{Rc, Weak};
+
+use gloo_events::EventListener;
+use gloo_utils::window;
+#[cfg(feature = "serde")]
+use serde::de::DeserializeOwned;
+#[cfg(feature = "serde")]
+use serde::Serialize;
+use wasm_bindgen::{JsValue, UnwrapThrowExt};
+
+#[cfg(feature = "serde")]
+use crate::error::HistoryResult;
+use crate::history::History;
+use crate::listener::HistoryListener;
+use crate::location::Location;
+
+type WeakCallback = Weak<dyn Fn()>;
+
+/// A [`History`] that is implemented with [`web_sys::History`] and stores path in `#`(fragment).
+#[derive(Clone)]
+pub struct HashHistory {
+    inner: web_sys::History,
+    callbacks: Rc<RefCell<Vec<WeakCallback>>>,
+}
+
+impl fmt::Debug for HashHistory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HashHistory").finish()
+    }
+}
+
+impl PartialEq for HashHistory {
+    fn eq(&self, _rhs: &Self) -> bool {
+        // All hash histories are created equal.
+        true
+    }
+}
+
+impl History for HashHistory {
+    type Location = HashLocation;
+
+    fn len(&self) -> usize {
+        self.inner.length().expect_throw("failed to get length.") as usize
+    }
+
+    fn go(&self, delta: isize) {
+        self.inner
+            .go_with_delta(delta as i32)
+            .expect_throw("failed to call go.")
+    }
+
+    fn push<'a>(&self, route: impl Into<Cow<'a, str>>) {
+        let url = route.into();
+        self.inner
+            .push_state_with_url(&JsValue::NULL, "", Some(&url))
+            .expect_throw("failed to push state.");
+
+        self.notify_callbacks();
+    }
+
+    fn replace<'a>(&self, route: impl Into<Cow<'a, str>>) {
+        let url = route.into();
+        self.inner
+            .replace_state_with_url(&JsValue::NULL, "", Some(&url))
+            .expect_throw("failed to replace history.");
+
+        self.notify_callbacks();
+    }
+
+    #[cfg(feature = "state")]
+    fn push_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T) -> HistoryResult<()>
+    where
+        T: Serialize + 'static,
+    {
+        let url = route.into();
+        let state = serde_wasm_bindgen::to_value(&state)?;
+        self.inner
+            .push_state_with_url(&state, "", Some(&url))
+            .expect_throw("failed to push state.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    #[cfg(feature = "state")]
+    fn replace_with_state<'a, T>(
+        &self,
+        route: impl Into<Cow<'a, str>>,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        T: Serialize + 'static,
+    {
+        let url = route.into();
+        let state = serde_wasm_bindgen::to_value(&state)?;
+        self.inner
+            .replace_state_with_url(&state, "", Some(&url))
+            .expect_throw("failed to replace state.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    #[cfg(feature = "query")]
+    fn push_with_query<'a, Q>(&self, route: impl Into<Cow<'a, str>>, query: Q) -> HistoryResult<()>
+    where
+        Q: Serialize,
+    {
+        let url = route.into();
+        let query = serde_urlencoded::to_string(query)?;
+        self.inner
+            .push_state_with_url(&JsValue::NULL, "", Some(&format!("{}?{}", url, query)))
+            .expect_throw("failed to push history.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+    #[cfg(feature = "query")]
+    fn replace_with_query<'a, Q>(
+        &self,
+        route: impl Into<Cow<'a, str>>,
+        query: Q,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+    {
+        let url = route.into();
+        let query = serde_urlencoded::to_string(query)?;
+        self.inner
+            .replace_state_with_url(&JsValue::NULL, "", Some(&format!("{}?{}", url, query)))
+            .expect_throw("failed to replace history.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    #[cfg(all(feature = "query", feature = "state"))]
+    fn push_with_query_and_state<'a, Q, T>(
+        &self,
+        route: impl Into<Cow<'a, str>>,
+        query: Q,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+        T: Serialize + 'static,
+    {
+        let url = route.into();
+        let query = serde_urlencoded::to_string(query)?;
+        let state = serde_wasm_bindgen::to_value(&state)?;
+        self.inner
+            .push_state_with_url(&state, "", Some(&format!("{}?{}", url, query)))
+            .expect_throw("failed to push history.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    #[cfg(all(feature = "query", feature = "state"))]
+    fn replace_with_query_and_state<'a, Q, T>(
+        &self,
+        route: impl Into<Cow<'a, str>>,
+        query: Q,
+        state: T,
+    ) -> HistoryResult<()>
+    where
+        Q: Serialize,
+        T: Serialize + 'static,
+    {
+        let url = route.into();
+        let query = serde_urlencoded::to_string(query)?;
+        let state = serde_wasm_bindgen::to_value(&state)?;
+        self.inner
+            .replace_state_with_url(&state, "", Some(&format!("{}?{}", url, query)))
+            .expect_throw("failed to replace history.");
+
+        self.notify_callbacks();
+        Ok(())
+    }
+
+    fn listen<CB>(&self, callback: CB) -> HistoryListener
+    where
+        CB: Fn() + 'static,
+    {
+        // Callbacks do not receive a copy of [`History`] to prevent reference cycle.
+        let cb = Rc::new(callback) as Rc<dyn Fn()>;
+
+        self.callbacks.borrow_mut().push(Rc::downgrade(&cb));
+
+        HistoryListener { _listener: cb }
+    }
+
+    fn location(&self) -> Self::Location {
+        HashLocation::new(self.clone())
+    }
+}
+
+impl Default for HashHistory {
+    fn default() -> Self {
+        // We create browser history only once.
+        thread_local! {
+            static BROWSER_HISTORY: RefCell<Option<HashHistory>> = RefCell::default();
+            static LISTENER: RefCell<Option<EventListener>> = RefCell::default();
+        }
+
+        BROWSER_HISTORY.with(|m| {
+            let mut m = m.borrow_mut();
+
+            let history = match *m {
+                Some(ref m) => m.clone(),
+                None => {
+                    let window = window();
+
+                    let inner = window
+                        .history()
+                        .expect_throw("Failed to create browser history. Are you using a browser?");
+                    let callbacks = Rc::default();
+
+                    let history = Self { inner, callbacks };
+
+                    {
+                        let history = history.clone();
+
+                        // Listens to popstate.
+                        LISTENER.with(move |m| {
+                            let mut listener = m.borrow_mut();
+
+                            *listener = Some(EventListener::new(&window, "popstate", move |_| {
+                                history.notify_callbacks();
+                            }));
+                        });
+                    }
+
+                    history
+                }
+            };
+
+            *m = Some(history.clone());
+
+            history
+        })
+    }
+}
+
+impl HashHistory {
+    /// Creates a new [`HashHistory`]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn notify_callbacks(&self) {
+        let callables = {
+            let mut callbacks_ref = self.callbacks.borrow_mut();
+
+            // Any gone weak references are removed when called.
+            let (callbacks, callbacks_weak) = callbacks_ref.iter().cloned().fold(
+                (Vec::new(), Vec::new()),
+                |(mut callbacks, mut callbacks_weak), m| {
+                    if let Some(m_strong) = m.clone().upgrade() {
+                        callbacks.push(m_strong);
+                        callbacks_weak.push(m);
+                    }
+
+                    (callbacks, callbacks_weak)
+                },
+            );
+
+            *callbacks_ref = callbacks_weak;
+
+            callbacks
+        };
+
+        for callback in callables {
+            callback()
+        }
+    }
+}
+
+/// The [`Location`] type for [`HashHistory`].
+#[derive(Clone)]
+pub struct HashLocation {
+    inner: web_sys::Location,
+    history: HashHistory,
+}
+
+impl fmt::Debug for HashLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HashLocation").finish()
+    }
+}
+
+impl PartialEq for HashLocation {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.history == rhs.history
+    }
+}
+
+impl Location for HashLocation {
+    type History = HashHistory;
+
+    fn path(&self) -> String {
+        self.inner
+            .pathname()
+            .expect_throw("failed to get pathname.")
+    }
+
+    fn search(&self) -> String {
+        self.inner.search().expect_throw("failed to get search.")
+    }
+
+    #[cfg(feature = "query")]
+    fn query<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let query = self.search();
+        serde_urlencoded::from_str(query.strip_prefix('?').unwrap_or("")).map_err(|e| e.into())
+    }
+
+    fn hash(&self) -> String {
+        self.inner.hash().expect_throw("failed to get hash.")
+    }
+
+    #[cfg(feature = "state")]
+    fn state<T>(&self) -> HistoryResult<T>
+    where
+        T: DeserializeOwned + 'static,
+    {
+        serde_wasm_bindgen::from_value(
+            self.history
+                .inner
+                .state()
+                .expect_throw("failed to read state."),
+        )
+        .map_err(|e| e.into())
+    }
+}
+
+impl HashLocation {
+    fn new(history: HashHistory) -> Self {
+        Self {
+            inner: window().location(),
+            history,
+        }
+    }
+}

--- a/crates/history/src/hash.rs
+++ b/crates/history/src/hash.rs
@@ -202,6 +202,7 @@ impl History for HashHistory {
 
     fn location(&self) -> Location {
         let inner_loc = self.inner.location();
+        // We strip # from hash.
         let hash_url = inner_loc.hash().chars().skip(1).collect::<String>();
 
         assert!(

--- a/crates/history/src/hash.rs
+++ b/crates/history/src/hash.rs
@@ -283,17 +283,8 @@ impl Location for HashLocation {
         self.location_url().pathname()
     }
 
-    fn search(&self) -> String {
+    fn query_str(&self) -> String {
         self.location_url().search()
-    }
-
-    #[cfg(feature = "query")]
-    fn query<T>(&self) -> HistoryResult<T>
-    where
-        T: DeserializeOwned,
-    {
-        let query = self.search();
-        serde_urlencoded::from_str(query.strip_prefix('?').unwrap_or("")).map_err(|e| e.into())
     }
 
     fn hash(&self) -> String {

--- a/crates/history/src/hash.rs
+++ b/crates/history/src/hash.rs
@@ -443,12 +443,19 @@ impl HashLocation {
     }
 
     fn location_url(&self) -> Url {
+        let hash_url = self
+            .inner
+            .hash()
+            .map(|m| m.chars().skip(1).collect::<String>())
+            .expect_throw("failed to get hash.");
+
+        assert!(
+            hash_url.starts_with('/'),
+            "hash-based url cannot be relative path."
+        );
+
         Url::new_with_base(
-            &self
-                .inner
-                .hash()
-                .map(|m| m.chars().skip(1).collect::<String>())
-                .expect_throw("failed to get hash."),
+            &hash_url,
             &self.inner.href().expect_throw("failed to get current url"),
         )
         .expect_throw("failed to get make url")

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -8,6 +8,11 @@ use crate::listener::HistoryListener;
 use crate::location::Location;
 
 /// A trait to provide [`History`] access.
+///
+/// # Warning
+///
+/// The behaviour of this trait is not well-defined when you mix multiple history kinds in the same application
+/// or use `window().history()` to update session history.
 pub trait History: Clone + PartialEq {
     /// Returns the number of elements in [`History`].
     fn len(&self) -> usize;

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -57,7 +57,7 @@ pub trait History: Clone + PartialEq {
     ///
     /// The implementation of state serialization differs between [`History`] types.
     ///
-    /// For [`BrowserHistory`], it uses [`serde_wasm_bindgen`] where as other types uses
+    /// For [`BrowserHistory`] and [`HashHistory`], it uses [`serde_wasm_bindgen`] where as other types uses
     /// [`Any`](std::any::Any).
     #[cfg(feature = "state")]
     fn replace_with_state<'a, T>(

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -1,18 +1,14 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "serde")]
 use serde::Serialize;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "query")]
 use crate::error::HistoryResult;
 use crate::listener::HistoryListener;
 use crate::location::Location;
 
 /// A trait to provide [`History`] access.
 pub trait History: Clone + PartialEq {
-    /// The [`Location`] type for current history.
-    type Location: Location<History = Self> + 'static;
-
     /// Returns the number of elements in [`History`].
     fn len(&self) -> usize;
 
@@ -43,30 +39,14 @@ pub trait History: Clone + PartialEq {
     fn replace<'a>(&self, route: impl Into<Cow<'a, str>>);
 
     /// Pushes a route entry with state.
-    ///
-    /// The implementation of state serialization differs between [`History`] types.
-    ///
-    /// For [`BrowserHistory`] and [`HashHistory`], state is serialised with [`serde_wasm_bindgen`] where as
-    /// [`MemoryHistory`] uses [`Any`](std::any::Any).
-    #[cfg(feature = "state")]
-    fn push_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T) -> HistoryResult<()>
+    fn push_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T)
     where
-        T: Serialize + 'static;
+        T: 'static;
 
     /// Replaces the current history entry with provided route and state.
-    ///
-    /// The implementation of state serialization differs between [`History`] types.
-    ///
-    /// For [`BrowserHistory`] and [`HashHistory`], it uses [`serde_wasm_bindgen`] where as other types uses
-    /// [`Any`](std::any::Any).
-    #[cfg(feature = "state")]
-    fn replace_with_state<'a, T>(
-        &self,
-        route: impl Into<Cow<'a, str>>,
-        state: T,
-    ) -> HistoryResult<()>
+    fn replace_with_state<'a, T>(&self, route: impl Into<Cow<'a, str>>, state: T)
     where
-        T: Serialize + 'static;
+        T: 'static;
 
     /// Same as `.push()` but affix the queries to the end of the route.
     #[cfg(feature = "query")]
@@ -85,7 +65,7 @@ pub trait History: Clone + PartialEq {
         Q: Serialize;
 
     /// Same as `.push_with_state()` but affix the queries to the end of the route.
-    #[cfg(all(feature = "query", feature = "state"))]
+    #[cfg(all(feature = "query"))]
     fn push_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -97,7 +77,7 @@ pub trait History: Clone + PartialEq {
         T: Serialize + 'static;
 
     /// Same as `.replace_with_state()` but affix the queries to the end of the route.
-    #[cfg(all(feature = "query", feature = "state"))]
+    #[cfg(all(feature = "query"))]
     fn replace_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -116,6 +96,6 @@ pub trait History: Clone + PartialEq {
     where
         CB: Fn() + 'static;
 
-    /// Returns the associated [`Location`] of the current history.
-    fn location(&self) -> Self::Location;
+    /// Returns current [`Location`].
+    fn location(&self) -> Location;
 }

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -5,18 +5,20 @@
 
 mod any;
 mod browser;
-#[cfg(feature = "serde")]
+#[cfg(feature = "query")]
 mod error;
 mod hash;
 mod history;
 mod listener;
 mod location;
+mod state;
+mod utils;
 
-pub use any::{AnyHistory, AnyLocation};
-pub use browser::{BrowserHistory, BrowserLocation};
-pub use hash::{HashHistory, HashLocation};
+pub use any::AnyHistory;
+pub use browser::BrowserHistory;
+pub use hash::HashHistory;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "query")]
 pub use error::{HistoryError, HistoryResult};
 pub use history::History;
 pub use listener::HistoryListener;

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -7,12 +7,14 @@ mod any;
 mod browser;
 #[cfg(feature = "serde")]
 mod error;
+mod hash;
 mod history;
 mod listener;
 mod location;
 
 pub use any::{AnyHistory, AnyLocation};
 pub use browser::{BrowserHistory, BrowserLocation};
+pub use hash::{HashHistory, HashLocation};
 
 #[cfg(feature = "serde")]
 pub use error::{HistoryError, HistoryResult};

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -1,24 +1,45 @@
-#[cfg(feature = "serde")]
+use std::any::Any;
+use std::rc::Rc;
+
+#[cfg(feature = "query")]
 use serde::de::DeserializeOwned;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "query")]
 use crate::error::HistoryResult;
-use crate::history::History;
 
-/// A trait to to provide [`Location`] information.
-pub trait Location: Clone + PartialEq {
-    /// The [`History`] type for current [`Location`].
-    type History: History<Location = Self> + 'static;
+/// A history location.
+///
+/// This struct provides location information at the time [`History::location`] is called.
+#[derive(Clone, Debug)]
+pub struct Location {
+    pub(crate) path: Rc<String>,
+    pub(crate) query_str: Rc<String>,
+    pub(crate) hash: Rc<String>,
+    pub(crate) state: Option<Rc<dyn Any>>,
+    pub(crate) id: Option<u32>,
+}
+
+impl Location {
+    /// A unique id of current location
+    ///
+    /// Returns [`None`] if current location is not created by `gloo::history`.
+    pub fn id(&self) -> Option<u32> {
+        self.id
+    }
 
     /// Returns the `pathname` on the [`Location`] struct.
-    fn path(&self) -> String;
+    pub fn path(&self) -> &str {
+        &self.path
+    }
 
     /// Returns the queries of current URL in [`String`]
-    fn query_str(&self) -> String;
+    pub fn query_str(&self) -> &str {
+        &self.query_str
+    }
 
     /// Returns the queries of current URL parsed as `T`.
     #[cfg(feature = "query")]
-    fn query<T>(&self) -> HistoryResult<T>
+    pub fn query<T>(&self) -> HistoryResult<T>
     where
         T: DeserializeOwned,
     {
@@ -27,16 +48,28 @@ pub trait Location: Clone + PartialEq {
     }
 
     /// Returns the hash fragment of current URL.
-    fn hash(&self) -> String;
+    pub fn hash(&self) -> &str {
+        &self.hash
+    }
 
-    /// Returns the State.
+    /// Returns an Rc'ed state of current location.
     ///
-    /// The implementation differs between [`Location`] type.
-    ///
-    /// For [`BrowserLocation`] and [`HashLocation`], state is deserialised with [`serde_wasm_bindgen`] where as
-    /// [`MemoryLocation`] uses [`Any`](std::any::Any).
-    #[cfg(feature = "state")]
-    fn state<T>(&self) -> HistoryResult<T>
+    /// Returns [`None`] if state is not created by `gloo::history`, or state fails to downcast.
+    pub fn state<T>(&self) -> Option<Rc<T>>
     where
-        T: DeserializeOwned + 'static;
+        T: 'static,
+    {
+        self.state.clone().and_then(|m| m.downcast().ok())
+    }
+}
+
+impl PartialEq for Location {
+    fn eq(&self, rhs: &Self) -> bool {
+        if let Some(lhs) = self.id() {
+            if let Some(rhs) = rhs.id() {
+                return lhs == rhs;
+            }
+        }
+        false
+    }
 }

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -20,19 +20,23 @@ pub struct Location {
 }
 
 impl Location {
-    /// A unique id of current location
+    /// Returns a unique id of current location.
     ///
     /// Returns [`None`] if current location is not created by `gloo::history`.
+    ///
+    /// # Warning
+    ///
+    /// Depending on the sitation, the id may or may not be sequential / incremental.
     pub fn id(&self) -> Option<u32> {
         self.id
     }
 
-    /// Returns the `pathname` on the [`Location`] struct.
+    /// Returns the `pathname` of current location.
     pub fn path(&self) -> &str {
         &self.path
     }
 
-    /// Returns the queries of current URL in [`String`]
+    /// Returns the queries of current URL in [`&str`].
     pub fn query_str(&self) -> &str {
         &self.query_str
     }

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -14,13 +14,17 @@ pub trait Location: Clone + PartialEq {
     fn path(&self) -> String;
 
     /// Returns the queries of current URL in [`String`]
-    fn search(&self) -> String;
+    fn query_str(&self) -> String;
 
     /// Returns the queries of current URL parsed as `T`.
     #[cfg(feature = "query")]
     fn query<T>(&self) -> HistoryResult<T>
     where
-        T: DeserializeOwned;
+        T: DeserializeOwned,
+    {
+        let query = self.query_str();
+        serde_urlencoded::from_str(query.strip_prefix('?').unwrap_or("")).map_err(|e| e.into())
+    }
 
     /// Returns the hash fragment of current URL.
     fn hash(&self) -> String;

--- a/crates/history/src/state.rs
+++ b/crates/history/src/state.rs
@@ -1,0 +1,36 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::utils::get_id;
+
+/// A constant to prevent state collision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum HistoryStateKind {
+    #[serde(rename = "gloo_history_state")]
+    Gloo,
+}
+
+/// The state used by browser history to store history id.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct HistoryState {
+    id: u32,
+    kind: HistoryStateKind,
+}
+
+impl HistoryState {
+    pub fn new() -> HistoryState {
+        Self {
+            id: get_id(),
+            kind: HistoryStateKind::Gloo,
+        }
+    }
+
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+}
+
+pub(crate) type StateMap = HashMap<u32, Rc<dyn Any>>;

--- a/crates/history/src/utils.rs
+++ b/crates/history/src/utils.rs
@@ -1,0 +1,7 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
+pub(crate) fn get_id() -> u32 {
+    static ID_CTR: AtomicU32 = AtomicU32::new(0);
+
+    ID_CTR.fetch_add(1, Ordering::SeqCst)
+}

--- a/crates/history/tests/browser_history.rs
+++ b/crates/history/tests/browser_history.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use gloo_timers::future::sleep;
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-use gloo_history::{BrowserHistory, History, Location};
+use gloo_history::{BrowserHistory, History};
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/crates/history/tests/browser_history_feat_serialize.rs
+++ b/crates/history/tests/browser_history_feat_serialize.rs
@@ -56,7 +56,7 @@ mod feat_serialize {
             .unwrap();
 
         assert_eq!(history.location().path(), "/path");
-        assert_eq!(history.location().search(), "?a=something&b=123");
+        assert_eq!(history.location().query_str(), "?a=something&b=123");
         assert_eq!(
             history.location().query::<Query>().unwrap(),
             Query {

--- a/crates/history/tests/browser_history_feat_serialize.rs
+++ b/crates/history/tests/browser_history_feat_serialize.rs
@@ -2,15 +2,16 @@ use wasm_bindgen_test::wasm_bindgen_test_configure;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-#[cfg(all(feature = "query", feature = "state"))]
+#[cfg(all(feature = "query"))]
 mod feat_serialize {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
+    use std::rc::Rc;
     use std::time::Duration;
 
     use serde::{Deserialize, Serialize};
 
-    use gloo_history::{BrowserHistory, History, Location};
+    use gloo_history::{BrowserHistory, History};
 
     use gloo_timers::future::sleep;
 
@@ -65,23 +66,21 @@ mod feat_serialize {
             }
         );
 
-        history
-            .push_with_state(
-                "/path-c",
-                State {
-                    i: "something".to_string(),
-                    ii: 123,
-                },
-            )
-            .unwrap();
+        history.push_with_state(
+            "/path-c",
+            State {
+                i: "something".to_string(),
+                ii: 123,
+            },
+        );
 
         assert_eq!(history.location().path(), "/path-c");
         assert_eq!(
             history.location().state::<State>().unwrap(),
-            State {
+            Rc::new(State {
                 i: "something".to_string(),
                 ii: 123,
-            }
+            })
         );
     }
 }

--- a/crates/history/tests/hash_history.rs
+++ b/crates/history/tests/hash_history.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use gloo_timers::future::sleep;
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
-use gloo_history::{HashHistory, History, Location};
+use gloo_history::{HashHistory, History};
 use gloo_utils::window;
 
 wasm_bindgen_test_configure!(run_in_browser);

--- a/crates/history/tests/hash_history.rs
+++ b/crates/history/tests/hash_history.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use gloo_timers::future::sleep;
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+use gloo_history::{HashHistory, History, Location};
+use gloo_utils::window;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[test]
+async fn history_works() {
+    let history = HashHistory::new();
+    assert_eq!(history.location().path(), "/");
+    assert_eq!(window().location().pathname().unwrap(), "/");
+    assert_eq!(window().location().hash().unwrap(), "#/");
+
+    history.push("/path-a");
+    assert_eq!(history.location().path(), "/path-a");
+    assert_eq!(window().location().pathname().unwrap(), "/");
+    assert_eq!(window().location().hash().unwrap(), "#/path-a");
+
+    history.replace("/path-b");
+    assert_eq!(history.location().path(), "/path-b");
+    assert_eq!(window().location().pathname().unwrap(), "/");
+    assert_eq!(window().location().hash().unwrap(), "#/path-b");
+
+    history.back();
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(history.location().path(), "/");
+    assert_eq!(window().location().pathname().unwrap(), "/");
+    assert_eq!(window().location().hash().unwrap(), "#/");
+
+    history.forward();
+    sleep(Duration::from_millis(100)).await;
+    assert_eq!(history.location().path(), "/path-b");
+    assert_eq!(window().location().pathname().unwrap(), "/");
+    assert_eq!(window().location().hash().unwrap(), "#/path-b");
+}

--- a/crates/history/tests/hash_history_feat_serialize.rs
+++ b/crates/history/tests/hash_history_feat_serialize.rs
@@ -2,15 +2,16 @@ use wasm_bindgen_test::wasm_bindgen_test_configure;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-#[cfg(all(feature = "query", feature = "state"))]
+#[cfg(all(feature = "query"))]
 mod feat_serialize {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
+    use std::rc::Rc;
     use std::time::Duration;
 
     use serde::{Deserialize, Serialize};
 
-    use gloo_history::{HashHistory, History, Location};
+    use gloo_history::{HashHistory, History};
 
     use gloo_timers::future::sleep;
     use gloo_utils::window;
@@ -79,25 +80,23 @@ mod feat_serialize {
             }
         );
 
-        history
-            .push_with_state(
-                "/path-c",
-                State {
-                    i: "something".to_string(),
-                    ii: 123,
-                },
-            )
-            .unwrap();
+        history.push_with_state(
+            "/path-c",
+            State {
+                i: "something".to_string(),
+                ii: 123,
+            },
+        );
 
         assert_eq!(history.location().path(), "/path-c");
         assert_eq!(window().location().pathname().unwrap(), "/");
         assert_eq!(window().location().hash().unwrap(), "#/path-c");
         assert_eq!(
             history.location().state::<State>().unwrap(),
-            State {
+            Rc::new(State {
                 i: "something".to_string(),
                 ii: 123,
-            }
+            })
         );
     }
 }

--- a/crates/history/tests/hash_history_feat_serialize.rs
+++ b/crates/history/tests/hash_history_feat_serialize.rs
@@ -65,7 +65,7 @@ mod feat_serialize {
             .unwrap();
 
         assert_eq!(history.location().path(), "/path");
-        assert_eq!(history.location().search(), "?a=something&b=123");
+        assert_eq!(history.location().query_str(), "?a=something&b=123");
         assert_eq!(window().location().pathname().unwrap(), "/");
         assert_eq!(
             window().location().hash().unwrap(),

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -13,7 +13,7 @@ use wasm_bindgen::JsCast;
 #[derive(Debug)]
 pub struct AnimationFrame {
     render_id: i32,
-    closure: Closure<dyn Fn(JsValue)>,
+    _closure: Closure<dyn Fn(JsValue)>,
     callback_wrapper: Rc<RefCell<Option<CallbackWrapper>>>,
 }
 
@@ -59,7 +59,7 @@ where
 
     AnimationFrame {
         render_id,
-        closure: callback,
+        _closure: callback,
         callback_wrapper,
     }
 }

--- a/crates/timers/src/future.rs
+++ b/crates/timers/src/future.rs
@@ -43,7 +43,7 @@ use wasm_bindgen::prelude::*;
 #[derive(Debug)]
 #[must_use = "futures do nothing unless polled or spawned"]
 pub struct TimeoutFuture {
-    inner: Timeout,
+    _inner: Timeout,
     rx: oneshot::Receiver<()>,
 }
 
@@ -71,7 +71,7 @@ impl TimeoutFuture {
             // if the receiver was dropped we do nothing.
             tx.send(()).unwrap_throw();
         });
-        TimeoutFuture { inner, rx }
+        TimeoutFuture { _inner: inner, rx }
     }
 }
 
@@ -116,7 +116,7 @@ impl Future for TimeoutFuture {
 #[must_use = "streams do nothing unless polled or spawned"]
 pub struct IntervalStream {
     receiver: mpsc::UnboundedReceiver<()>,
-    inner: Interval,
+    _inner: Interval,
 }
 
 impl IntervalStream {
@@ -146,7 +146,10 @@ impl IntervalStream {
             sender.unbounded_send(()).unwrap_throw();
         });
 
-        IntervalStream { receiver, inner }
+        IntervalStream {
+            receiver,
+            _inner: inner,
+        }
     }
 }
 


### PR DESCRIPTION
This pull request consists of the following changes:
- `HashHistory` for hash-based history access.
- `Location` is now a struct and its content will be stable after created by `History::location()`.
- `Location` now have an `id` that is unique to itself.
- States now uses downcasting in all occasions.