### PR TITLE
Remove `web-sys` dependency in `gloo-timers`

### DIFF
--- a/crates/timers/Cargo.toml
+++ b/crates/timers/Cargo.toml
@@ -19,13 +19,6 @@ js-sys = "0.3.31"
 futures-core = { version = "0.3", optional = true }
 futures-channel = { version = "0.3", optional = true }
 
-[dependencies.web-sys]
-version = "0.3.19"
-features = [
-    "Window",
-    "WorkerGlobalScope",
-]
-
 [features]
 default = []
 futures = ["futures-core", "futures-channel"]


### PR DESCRIPTION
Remove the now unused `web-sys` dependency from the `gloo-timers` crate. This should've been part of #185 but was forgotten.

@hamza1311 