### PR TITLE
Fix `utils` crate and `history` docs.

### DIFF
--- a/crates/history/src/listener.rs
+++ b/crates/history/src/listener.rs
@@ -1,10 +1,10 @@
 use std::fmt;
 use std::rc::Rc;
 
-/// A History Listener to manage callbacks registered on a [`History`].
+/// A History Listener to manage callbacks registered on a [`History`][crate::History].
 ///
-/// This Listener has the same behaviour as the [`EventListener`] from [`gloo`]
-/// that the underlying callback will be unregistered when the listener is dropped.
+/// This Listener has the same behaviour as the [`EventListener`][gloo_events::EventListener] from
+/// `gloo` that the underlying callback will be unregistered when the listener is dropped.
 #[must_use = "the listener is removed when `HistoryListener` is dropped"]
 pub struct HistoryListener {
     pub(crate) _listener: Rc<dyn Fn()>,

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -9,7 +9,8 @@ use crate::error::HistoryResult;
 
 /// A history location.
 ///
-/// This struct provides location information at the time [`History::location`] is called.
+/// This struct provides location information at the time
+/// [`History::location`][crate::History::location] is called.
 #[derive(Clone, Debug)]
 pub struct Location {
     pub(crate) path: Rc<String>,

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -23,5 +23,6 @@ features = [
     "HtmlElement",
     "Location",
     "Window",
-    "HtmlHeadElement"
+    "HtmlHeadElement",
+    "Element",
 ]


### PR DESCRIPTION
Fixes a build error in `gloo-utils` and intra-doc links in `gloo-history`.