### PR TITLE
[events] Fix link to `EventListener` doc in README

### DIFF
--- a/crates/events/README.md
+++ b/crates/events/README.md
@@ -24,4 +24,4 @@ provides an [`EventListener`] type which makes it easy!
 
 See the documentation for [`EventListener`] for more information.
 
-[`EventListener`]: struct.EventListener.html
+[`EventListener`]: https://docs.rs/gloo-events/latest/gloo_events/struct.EventListener.html


### PR DESCRIPTION
Using the absolute link to the docs, so that it works anywhere.