### PR TITLE
Worker: support rkyv in additon to bincode

### DIFF
--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -18,7 +18,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 anymap2 = "0.13"
-bincode = "1"
 gloo-console = { path = "../console", version = "0.2" }
 gloo-utils = { path = "../utils", version = "0.1" }
 js-sys = "0.3"
@@ -26,6 +25,9 @@ serde = { version = "1", features = ["derive"] }
 slab = "0.4"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = { version = "0.4", optional = true }
+bincode = { version = "1", optional = true }
+rkyv = { version = "0.7", optional = true, features = ["validation"] }
+bytecheck = { version = "0.6", optional = true }
 
 [dependencies.web-sys]
 version = "0.3"
@@ -40,5 +42,7 @@ features = [
 ]
 
 [features]
-default = []
-futures = ["wasm-bindgen-futures"]
+default = ["bincode"]
+bincode = ["dep:bincode"]
+rkyv = ["dep:rkyv", "dep:bytecheck"]
+futures = ["dep:wasm-bindgen-futures"]

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -45,7 +45,6 @@ pub use pool::{Dispatched, Dispatcher};
 use std::cell::RefCell;
 pub use worker::{Private, PrivateWorker, Public, PublicWorker};
 
-use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
@@ -108,7 +107,12 @@ pub trait Worker: Sized + 'static {
 }
 
 /// Id of responses handler.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Hash, Clone, Copy)]
+#[cfg_attr(feature = "bincode", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub struct HandlerId(usize, bool);
 
 impl HandlerId {

--- a/crates/worker/src/worker/mod.rs
+++ b/crates/worker/src/worker/mod.rs
@@ -52,6 +52,7 @@ impl<T: rkyv::Archive + rkyv::Serialize<rkyv::Infallible>> Packed for T {
     }
 
     fn unpack(data: &[u8]) -> Self {
+        use rkyv::Deserialize;
         let archived =
             rkyv::check_archived_root::<Self>(data).expect("check worker message with rkyv failed");
         archived

--- a/crates/worker/src/worker/private.rs
+++ b/crates/worker/src/worker/private.rs
@@ -3,7 +3,6 @@ use crate::{
     Bridge, Callback, Discoverer, HandlerId, Worker, WorkerLifecycleEvent, WorkerLink, WorkerScope,
 };
 use queue::Queue;
-use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::fmt;
 use std::marker::PhantomData;
@@ -30,11 +29,11 @@ pub trait PrivateWorker {
     fn register();
 }
 
-impl<W> PrivateWorker for W
+impl<W, F> PrivateWorker for W
 where
     W: Worker<Reach = Private<W>>,
-    <W as Worker>::Input: Serialize + for<'de> Deserialize<'de>,
-    <W as Worker>::Output: Serialize + for<'de> Deserialize<'de>,
+    <W as Worker>::Input: SerDe<F>,
+    <W as Worker>::Output: SerDe<F>,
 {
     fn register() {
         let scope = WorkerScope::<W>::new();
@@ -73,11 +72,11 @@ where
     }
 }
 
-impl<W> Discoverer for Private<W>
+impl<W, F> Discoverer for Private<W>
 where
     W: Worker,
-    <W as Worker>::Input: Serialize + for<'de> Deserialize<'de>,
-    <W as Worker>::Output: Serialize + for<'de> Deserialize<'de>,
+    <W as Worker>::Input: SerDe<F>,
+    <W as Worker>::Output: SerDe<F>,
 {
     type Worker = W;
 
@@ -132,11 +131,11 @@ where
 }
 
 /// A connection manager for components interaction with workers.
-pub struct PrivateBridge<W, HNDL>
+pub struct PrivateBridge<W, HNDL, F>
 where
     W: Worker,
-    <W as Worker>::Input: Serialize + for<'de> Deserialize<'de>,
-    <W as Worker>::Output: Serialize + for<'de> Deserialize<'de>,
+    <W as Worker>::Input: SerDe<F>,
+    <W as Worker>::Output: SerDe<F>,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     handler_cell: Rc<RefCell<Option<HNDL>>>,
@@ -145,11 +144,11 @@ where
     id: usize,
 }
 
-impl<W, HNDL> PrivateBridge<W, HNDL>
+impl<W, HNDL, F> PrivateBridge<W, HNDL, F>
 where
     W: Worker,
-    <W as Worker>::Input: Serialize + for<'de> Deserialize<'de>,
-    <W as Worker>::Output: Serialize + for<'de> Deserialize<'de>,
+    <W as Worker>::Input: SerDe<F>,
+    <W as Worker>::Output: SerDe<F>,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     /// Send a message to the worker, queuing the message if necessary
@@ -164,11 +163,11 @@ where
     }
 }
 
-impl<W, HNDL> fmt::Debug for PrivateBridge<W, HNDL>
+impl<W, HNDL, F> fmt::Debug for PrivateBridge<W, HNDL, F>
 where
     W: Worker,
-    <W as Worker>::Input: Serialize + for<'de> Deserialize<'de>,
-    <W as Worker>::Output: Serialize + for<'de> Deserialize<'de>,
+    <W as Worker>::Input: SerDe<F>,
+    <W as Worker>::Output: SerDe<F>,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -176,11 +175,11 @@ where
     }
 }
 
-impl<W, HNDL> Bridge<W> for PrivateBridge<W, HNDL>
+impl<W, HNDL, F> Bridge<W> for PrivateBridge<W, HNDL, F>
 where
     W: Worker,
-    <W as Worker>::Input: Serialize + for<'de> Deserialize<'de>,
-    <W as Worker>::Output: Serialize + for<'de> Deserialize<'de>,
+    <W as Worker>::Input: SerDe<F>,
+    <W as Worker>::Output: SerDe<F>,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     fn send(&mut self, msg: W::Input) {
@@ -189,11 +188,11 @@ where
     }
 }
 
-impl<W, HNDL> Drop for PrivateBridge<W, HNDL>
+impl<W, HNDL, F> Drop for PrivateBridge<W, HNDL, F>
 where
     W: Worker,
-    <W as Worker>::Input: Serialize + for<'de> Deserialize<'de>,
-    <W as Worker>::Output: Serialize + for<'de> Deserialize<'de>,
+    <W as Worker>::Input: SerDe<F>,
+    <W as Worker>::Output: SerDe<F>,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     fn drop(&mut self) {

--- a/crates/worker/src/worker/private.rs
+++ b/crates/worker/src/worker/private.rs
@@ -29,11 +29,11 @@ pub trait PrivateWorker {
     fn register();
 }
 
-impl<W, F> PrivateWorker for W
+impl<W> PrivateWorker for W
 where
     W: Worker<Reach = Private<W>>,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     fn register() {
         let scope = WorkerScope::<W>::new();
@@ -72,11 +72,11 @@ where
     }
 }
 
-impl<W, F> Discoverer for Private<W>
+impl<W> Discoverer for Private<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     type Worker = W;
 
@@ -131,11 +131,11 @@ where
 }
 
 /// A connection manager for components interaction with workers.
-pub struct PrivateBridge<W, HNDL, F>
+pub struct PrivateBridge<W, HNDL>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     handler_cell: Rc<RefCell<Option<HNDL>>>,
@@ -144,11 +144,11 @@ where
     id: usize,
 }
 
-impl<W, HNDL, F> PrivateBridge<W, HNDL, F>
+impl<W, HNDL> PrivateBridge<W, HNDL>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     /// Send a message to the worker, queuing the message if necessary
@@ -163,11 +163,11 @@ where
     }
 }
 
-impl<W, HNDL, F> fmt::Debug for PrivateBridge<W, HNDL, F>
+impl<W, HNDL> fmt::Debug for PrivateBridge<W, HNDL>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -175,11 +175,11 @@ where
     }
 }
 
-impl<W, HNDL, F> Bridge<W> for PrivateBridge<W, HNDL, F>
+impl<W, HNDL> Bridge<W> for PrivateBridge<W, HNDL>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     fn send(&mut self, msg: W::Input) {
@@ -188,11 +188,11 @@ where
     }
 }
 
-impl<W, HNDL, F> Drop for PrivateBridge<W, HNDL, F>
+impl<W, HNDL> Drop for PrivateBridge<W, HNDL>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
     HNDL: Fn(Vec<u8>, &web_sys::Worker),
 {
     fn drop(&mut self) {

--- a/crates/worker/src/worker/public.rs
+++ b/crates/worker/src/worker/public.rs
@@ -23,11 +23,11 @@ pub struct Public<W> {
     _worker: PhantomData<W>,
 }
 
-impl<W, F> Discoverer for Public<W>
+impl<W> Discoverer for Public<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     type Worker = W;
 
@@ -82,42 +82,42 @@ where
     }
 }
 
-impl<W, F> Dispatchable for Public<W>
+impl<W> Dispatchable for Public<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
 }
 
 /// A connection manager for components interaction with workers.
-pub struct PublicBridge<W, F>
+pub struct PublicBridge<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     worker: web_sys::Worker,
     id: HandlerId,
     _worker: PhantomData<W>,
 }
 
-impl<W, F> fmt::Debug for PublicBridge<W, F>
+impl<W> fmt::Debug for PublicBridge<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("PublicBridge<_>")
     }
 }
 
-impl<W, F> PublicBridge<W, F>
+impl<W> PublicBridge<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     /// Send a message to the worker, queuing the message if necessary
     fn send_message(&self, msg: ToWorker<W::Input>) {
@@ -131,11 +131,11 @@ where
     }
 }
 
-impl<W, F> Bridge<W> for PublicBridge<W, F>
+impl<W> Bridge<W> for PublicBridge<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     fn send(&mut self, msg: W::Input) {
         let msg = ToWorker::ProcessInput(self.id, msg);
@@ -143,11 +143,11 @@ where
     }
 }
 
-impl<W, F> Drop for PublicBridge<W, F>
+impl<W> Drop for PublicBridge<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     fn drop(&mut self) {
         let terminate_worker = REMOTE_WORKERS_POOL.with(|pool| {
@@ -188,11 +188,11 @@ pub trait PublicWorker {
     fn register();
 }
 
-impl<W, F> PublicWorker for W
+impl<W> PublicWorker for W
 where
     W: Worker<Reach = Public<W>>,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     fn register() {
         let scope = WorkerScope::<W>::new();
@@ -231,27 +231,27 @@ where
     }
 }
 
-struct RemoteWorker<W, F>
+struct RemoteWorker<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     worker: web_sys::Worker,
     slab: SharedOutputSlab<W>,
 }
 
-impl<W, F> RemoteWorker<W, F>
+impl<W> RemoteWorker<W>
 where
     W: Worker,
-    <W as Worker>::Input: SerDe<F>,
-    <W as Worker>::Output: SerDe<F>,
+    <W as Worker>::Input: SerDe,
+    <W as Worker>::Output: SerDe,
 {
     pub fn new(worker: web_sys::Worker, slab: SharedOutputSlab<W>) -> Self {
         RemoteWorker { worker, slab }
     }
 
-    fn create_bridge(&mut self, callback: Option<Callback<W::Output>>) -> PublicBridge<W, F> {
+    fn create_bridge(&mut self, callback: Option<Callback<W::Output>>) -> PublicBridge<W> {
         let respondable = callback.is_some();
         let mut slab = self.slab.borrow_mut();
         let id: usize = slab.insert(callback);
@@ -266,7 +266,7 @@ where
         bridge
     }
 
-    fn remove_bridge(&mut self, bridge: &PublicBridge<W, F>) -> Last {
+    fn remove_bridge(&mut self, bridge: &PublicBridge<W>) -> Last {
         let mut slab = self.slab.borrow_mut();
         let _ = slab.remove(bridge.id.raw_id());
         slab.is_empty()


### PR DESCRIPTION
I ran into issue https://github.com/bincode-org/bincode/issues/245 in bincode, which will seemingly not be fixed https://github.com/serde-rs/serde/issues/1346 without the implementation of a new stricter flatten attribute in serde.

Although I could remove `#[serde(flatten)]` from my type, but that only sidesteps the problem.

It would be best if gloo_worker supports something other than serde+bincode, so this attempts to add rkyv.