### PR TITLE
Implement std Error trait for JsError

### DIFF
--- a/crates/utils/src/errors.rs
+++ b/crates/utils/src/errors.rs
@@ -76,3 +76,5 @@ impl fmt::Debug for JsError {
             .finish()
     }
 }
+
+impl std::error::Error for JsError {}


### PR DESCRIPTION
Implement `std::error::Error` for `gloo_utils::errors::JsError`.
Closes #216.