### PR TITLE
[rfc] Implement an ObjectUrl wrapper

### DIFF
--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -31,12 +31,18 @@ features = [
     "BlobPropertyBag",
     "FilePropertyBag",
     "DomException",
+    "Url",
 ]
 
 [dev-dependencies]
 futures_rs = { version = "0.3", package = "futures" }
 wasm-bindgen-test = "0.3.4"
+wasm-bindgen-futures = "0.4"
 chrono = { version = "0.4.10", features = ["wasmbind"] }
+
+[dev-dependencies.web-sys]
+version = "0.3.31"
+features = ["Window", "Response"]
 
 [features]
 default = []

--- a/crates/file/src/blob.rs
+++ b/crates/file/src/blob.rs
@@ -1,14 +1,10 @@
+use crate::Sealed;
 use std::{
     ops::Deref,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use wasm_bindgen::{prelude::*, throw_str, JsCast};
-
-mod sealed {
-    pub trait Sealed {}
-}
-use sealed::Sealed;
 
 /// This trait is used to overload the `Blob::new_with_options` function, allowing a variety of
 /// types to be used to create a `Blob`. Ignore this, and use &\[u8], &str, etc to create a `Blob`.

--- a/crates/file/src/lib.rs
+++ b/crates/file/src/lib.rs
@@ -9,7 +9,14 @@
 mod blob;
 mod file_list;
 mod file_reader;
+mod object_url;
 
 pub use blob::*;
 pub use file_list::*;
 pub use file_reader::*;
+pub use object_url::*;
+
+mod sealed {
+    pub trait Sealed {}
+}
+use sealed::Sealed;

--- a/crates/file/src/object_url.rs
+++ b/crates/file/src/object_url.rs
@@ -1,0 +1,83 @@
+use crate::{Blob, Sealed};
+use std::{ops::Deref, rc::Rc};
+
+use wasm_bindgen::UnwrapThrowExt;
+use web_sys::Url;
+
+struct ObjectUrlAllocation {
+    url: String,
+}
+
+/// This trait is used to overload the `Url::create_object_url` function, allowing a variety of
+/// types to be used to create a [`ObjectUrl`]. Ignore this, and use [`Blob`] or [`File`] to create one.
+///
+/// The trait is sealed: it can only be implemented by types in this
+/// crate, as this crate relies on invariants regarding the `JsValue` returned from `into_jsvalue`.
+///
+/// [`File`]: crate::File
+pub trait ObjectUrlTarget: Sealed {
+    fn create_new_object_url(&self) -> String;
+}
+
+impl ObjectUrlTarget for Blob {
+    fn create_new_object_url(&self) -> String {
+        Url::create_object_url_with_blob(self.as_ref()).unwrap_throw()
+    }
+}
+
+impl Sealed for web_sys::Blob {}
+impl ObjectUrlTarget for web_sys::Blob {
+    fn create_new_object_url(&self) -> String {
+        Url::create_object_url_with_blob(self).unwrap_throw()
+    }
+}
+
+// Note: some browsers support Url::create_object_url_with_source but this is deprecated!
+// https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL#using_object_urls_for_media_streams
+
+impl ObjectUrlAllocation {
+    fn allocate_new_object_url(target: &dyn ObjectUrlTarget) -> Self {
+        let url = target.create_new_object_url();
+        Self { url }
+    }
+}
+
+impl Drop for ObjectUrlAllocation {
+    fn drop(&mut self) {
+        web_sys::Url::revoke_object_url(&self.url).unwrap_throw();
+    }
+}
+
+/// A resource wrapper around [`URL.createObjectURL`] / [`URL.revokeObjectURL`].
+///
+/// A [`Blob`], in particular a [`File`], can be converted to a short URL representing its data with the above methods.
+/// An [`ObjectUrl`] can be cheaply cloned and shared and revokes the underlying URL when the last reference is dropped.
+///
+/// Note that multiple urls can be created for the same blob, without being guaranteed to be de-deduplicated.
+///
+/// [`URL.createObjectURL`]: https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL
+/// [`URL.revokeObjectURL`]: https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL
+/// [`File`]: crate::File
+#[derive(Clone)]
+pub struct ObjectUrl {
+    inner: Rc<ObjectUrlAllocation>,
+}
+
+impl ObjectUrl {
+    /// Create a new ObjectUrl from a [`Blob`] or [`File`].
+    ///
+    /// [`File`]: crate::File
+    pub fn new(target: &dyn ObjectUrlTarget) -> Self {
+        Self {
+            inner: Rc::new(ObjectUrlAllocation::allocate_new_object_url(target)),
+        }
+    }
+}
+
+impl Deref for ObjectUrl {
+    type Target = String;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.url
+    }
+}

--- a/crates/file/src/object_url.rs
+++ b/crates/file/src/object_url.rs
@@ -1,4 +1,4 @@
-use crate::{Blob, Sealed};
+use crate::{Blob, File};
 use std::{ops::Deref, rc::Rc};
 
 use wasm_bindgen::UnwrapThrowExt;
@@ -6,40 +6,6 @@ use web_sys::Url;
 
 struct ObjectUrlAllocation {
     url: String,
-}
-
-/// This trait is used to overload the `Url::create_object_url` function, allowing a variety of
-/// types to be used to create a [`ObjectUrl`]. Ignore this, and use [`Blob`] or [`File`] to create one.
-///
-/// The trait is sealed: it can only be implemented by types in this
-/// crate, as this crate relies on invariants regarding the `JsValue` returned from `into_jsvalue`.
-///
-/// [`File`]: crate::File
-pub trait ObjectUrlTarget: Sealed {
-    fn create_new_object_url(&self) -> String;
-}
-
-impl ObjectUrlTarget for Blob {
-    fn create_new_object_url(&self) -> String {
-        Url::create_object_url_with_blob(self.as_ref()).unwrap_throw()
-    }
-}
-
-impl Sealed for web_sys::Blob {}
-impl ObjectUrlTarget for web_sys::Blob {
-    fn create_new_object_url(&self) -> String {
-        Url::create_object_url_with_blob(self).unwrap_throw()
-    }
-}
-
-// Note: some browsers support Url::create_object_url_with_source but this is deprecated!
-// https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL#using_object_urls_for_media_streams
-
-impl ObjectUrlAllocation {
-    fn allocate_new_object_url(target: &dyn ObjectUrlTarget) -> Self {
-        let url = target.create_new_object_url();
-        Self { url }
-    }
 }
 
 impl Drop for ObjectUrlAllocation {
@@ -55,6 +21,15 @@ impl Drop for ObjectUrlAllocation {
 ///
 /// Note that multiple urls can be created for the same blob, without being guaranteed to be de-deduplicated.
 ///
+/// # Example
+///
+/// ```rust,no_run
+/// use gloo_file::{Blob, ObjectUrl};
+///
+/// let blob = Blob::new("hello world");
+/// let object_url = ObjectUrl::from(blob);
+/// ```
+///
 /// [`URL.createObjectURL`]: https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL
 /// [`URL.revokeObjectURL`]: https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL
 /// [`File`]: crate::File
@@ -63,19 +38,31 @@ pub struct ObjectUrl {
     inner: Rc<ObjectUrlAllocation>,
 }
 
-impl ObjectUrl {
-    /// Create a new ObjectUrl from a [`Blob`] or [`File`].
-    ///
-    /// [`File`]: crate::File
-    pub fn new(target: &dyn ObjectUrlTarget) -> Self {
-        Self {
-            inner: Rc::new(ObjectUrlAllocation::allocate_new_object_url(target)),
-        }
+impl From<File> for ObjectUrl {
+    fn from(file: File) -> Self {
+        Blob::from(file).into()
     }
 }
 
+impl From<Blob> for ObjectUrl {
+    fn from(blob: Blob) -> Self {
+        web_sys::Blob::from(blob).into()
+    }
+}
+
+impl From<web_sys::Blob> for ObjectUrl {
+    fn from(blob: web_sys::Blob) -> Self {
+        let url = Url::create_object_url_with_blob(&blob).unwrap_throw();
+        let inner = Rc::new(ObjectUrlAllocation { url });
+        Self { inner }
+    }
+}
+
+// Note: some browsers support Url::create_object_url_with_source but this is deprecated!
+// https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL#using_object_urls_for_media_streams
+
 impl Deref for ObjectUrl {
-    type Target = String;
+    type Target = str;
 
     fn deref(&self) -> &Self::Target {
         &self.inner.url

--- a/crates/file/tests/web.rs
+++ b/crates/file/tests/web.rs
@@ -2,9 +2,12 @@
 
 use futures_rs::channel::mpsc;
 use futures_rs::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
 
-use gloo_file::{callbacks::read_as_text, Blob, File};
+use gloo_file::{callbacks::read_as_text, Blob, File, ObjectUrl};
+use web_sys::{window, Response};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -104,3 +107,20 @@ const PNG_FILE: &'static [u8] = &[
 #[cfg(feature = "futures")]
 const PNG_FILE_DATA: &'static str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAA\
      Al21bKAAAAA1BMVEX/TQBcNTh/AAAAAXRSTlPM0jRW/QAAAApJREFUeJxjYgAAAAYAAzY3fKgAAAAASUVORK5CYII=";
+
+#[cfg(feature = "futures")]
+#[wasm_bindgen_test]
+async fn blob_to_url() {
+    let blob = Blob::new("hello world");
+    let object_url = ObjectUrl::new(&blob);
+    // simulate a fetch, and expect to get a string containing the content back
+    let request: JsFuture = window().unwrap().fetch_with_str(&object_url).into();
+    let response = request.await.unwrap().unchecked_into::<Response>();
+    let body: JsFuture = response.blob().unwrap().into();
+    let body = body.await.unwrap().unchecked_into::<web_sys::Blob>();
+
+    let body = gloo_file::futures::read_as_text(&body.into())
+        .await
+        .unwrap();
+    assert_eq!(&body, "hello world");
+}

--- a/crates/file/tests/web.rs
+++ b/crates/file/tests/web.rs
@@ -112,7 +112,7 @@ const PNG_FILE_DATA: &'static str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEU
 #[wasm_bindgen_test]
 async fn blob_to_url() {
     let blob = Blob::new("hello world");
-    let object_url = ObjectUrl::new(&blob);
+    let object_url = ObjectUrl::from(blob);
     // simulate a fetch, and expect to get a string containing the content back
     let request: JsFuture = window().unwrap().fetch_with_str(&object_url).into();
     let response = request.await.unwrap().unchecked_into::<Response>();


### PR DESCRIPTION
## Rationale

The [`createObjectUrl`](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL) API is offered by the browser to create URLs from Blobs that are too large to represent as data urls. The resulting url is along the lines of `blob:[origin]://[uuid]`. There's a counter part [`revokeObjectURL`](https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL) that releases the URL again. Rust lends itself to an abstraction that automatically revokes the url when it is not need any longer.

## The API

A `struct ObjectUrl` abstracts the allocation of a specific ObjectUrl. It uses reference counting to revoke the Url after the last user drops its use. It can be created from a `Blob`, `File` or directly from a `web_sys::Blob`. A `Deref` implemention allows access to the stringly-typed url under-the-hood.
