### PR TITLE
Add dropdown for doc.rs in website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,9 +22,55 @@ module.exports = {
       items: [
         {to: '/blog', label: 'Blog', position: 'left'},
         {
-          href: 'https://docs.rs/gloo',
+          type: 'dropdown',
           label: 'docs.rs',
           position: 'right',
+          items: [
+            {
+              label: 'gloo',
+              href: 'https://docs.rs/gloo',
+            },
+            {
+              label: 'dialogs',
+              href: 'https://docs.rs/gloo-dialogs/',
+            },
+            {
+              label: 'events',
+              href: 'https://docs.rs/gloo-events/',
+            },
+            {
+              label: 'file',
+              href: 'https://docs.rs/gloo-file/',
+            },
+            {
+              label: 'history',
+              href: 'https://docs.rs/gloo-history/',
+            },
+            {
+              label: 'net',
+              href: 'https://docs.rs/gloo-net/',
+            },
+            {
+              label: 'render',
+              href: 'https://docs.rs/gloo-render/',
+            },
+            {
+              label: 'storage',
+              href: 'https://docs.rs/gloo-storage/',
+            },
+            {
+              label: 'timers',
+              href: 'https://docs.rs/gloo-timers/',
+            },
+            {
+              label: 'utils',
+              href: 'https://docs.rs/gloo-utils/',
+            },
+            {
+              label: 'worker',
+              href: 'https://docs.rs/gloo-worker/',
+            }
+          ],
         },
         {
           href: 'https://github.com/rustwasm/gloo',


### PR DESCRIPTION
# Motivation
Instead of opening gloo's doc.rs page allow the user to select a crate for documentation

<img width="203" alt="image" src="https://user-images.githubusercontent.com/32068075/179734131-c21e7b9b-f5f4-44f6-ab0f-4a863e444650.png">
