### PR TITLE
fix: Break dependency cycle by not using serde-serialize

### DIFF
--- a/crates/console/Cargo.toml
+++ b/crates/console/Cargo.toml
@@ -12,9 +12,10 @@ documentation = "https://docs.rs/gloo-console/"
 categories = ["api-bindings", "development-tools::profiling", "wasm"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1.0"
 [dependencies.web-sys]
 version = "0.3"
 features = [

--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -38,7 +38,7 @@ pub mod __macro {
         data: impl serde::Serialize,
         columns: impl IntoIterator<Item = &'a str>,
     ) {
-        let data = JsValue::from_serde(&data).unwrap_throw();
+        let data = js_sys::JSON::parse(&serde_json::to_string(&data).unwrap_throw()).unwrap_throw();
         let columns = columns.into_iter().map(JsValue::from_str).collect();
 
         crate::externs::table_with_data_and_columns(data, columns);

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -40,7 +40,7 @@ futures = "0.3"
 default = ["json", "websocket", "http"]
 
 # Enables `.json()` on `Response`
-json = ["wasm-bindgen/serde-serialize", "serde", "serde_json"]
+json = ["serde", "serde_json"]
 # Enables the WebSocket API
 websocket = [
     'web-sys/WebSocket',

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "storage", "wasm"]
 
 [dependencies]
-wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
+wasm-bindgen = "0.2"
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
There is [an issue](https://github.com/tkaitchuck/aHash/issues/95) with cyclic dependency when `serde-serialize` feature is enabled in `wasm-bindgen`. Current suggestion is to use `js_sys` instead to avoid it.

I’ve checked and modified every crate that was enabling this feature:

 - `console` was easy to change
 - `storage` didn’t actually depend on this feature, so I just removed it.
 - `net` this one was a bit tricky and this the create that I couldn’t run tests for.


I ran non-wasm tests, and wasm tests for console and storage.