### PR TITLE
Fix gloo-worker tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,15 +109,18 @@ jobs:
             cargo-${{ runner.os }}-test-worker-
             cargo-${{ runner.os }}-
 
-      - name: Run tests for gloo worker
+      - name: Build and Run Test Server
+        run: |
+          cargo build -p example-markdown --bin example_markdown_test_server
+          nohup target/debug/example_markdown_test_server examples/markdown/dist &
+
+      - name: Build Test Worker
         run: |
           trunk build examples/markdown/index.html
-          cargo build -p example-markdown --bin example_markdown_test_server
 
-          nohup target/debug/example_markdown_test_server examples/markdown/dist &
-          sleep 5
-
-          wasm-pack test --headless --firefox --chrome examples/markdown
+      - name: Run tests for gloo worker
+        run: |
+          wasm-pack test --headless --firefox examples/markdown
 
 
   test-net:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run tests for gloo worker
         run: |
-          wasm-pack test --headless --firefox examples/markdown
+          wasm-pack test --headless --firefox --chrome  examples/markdown
 
 
   test-net:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,10 @@ jobs:
       - name: Run tests for gloo worker
         run: |
           trunk build examples/markdown/index.html
-          nohup cargo run -p example-markdown --bin example_markdown_test_server -- examples/markdown/dist &
+          cargo build -p example-markdown --bin example_markdown_test_server
+
+          nohup target/debug/example_markdown_test_server examples/markdown/dist &
+          sleep 2
 
           wasm-pack test --headless --firefox --chrome examples/markdown
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,13 +76,46 @@ jobs:
             wasm-pack test --headless --firefox --chrome crates/$x --no-default-features
           done
 
+
+
+  test-worker:
+    name: Test gloo-worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          profile: minimal
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup trunk
+        uses: jetli/trunk-action@v0.1.0
+        with:
+          version: 'latest'
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-browser-tests-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-test-worker-
+            cargo-${{ runner.os }}-
+
       - name: Run tests for gloo worker
         run: |
           trunk build examples/markdown/index.html
           cargo build -p example-markdown --bin example_markdown_test_server
 
           nohup target/debug/example_markdown_test_server examples/markdown/dist &
-          sleep 2
+          sleep 5
 
           wasm-pack test --headless --firefox --chrome examples/markdown
 

--- a/examples/markdown/src/bin/example_markdown_test_server.rs
+++ b/examples/markdown/src/bin/example_markdown_test_server.rs
@@ -19,5 +19,7 @@ async fn main() {
             .allow_any_origin(),
     );
 
+    println!("Test server is running at: http://127.0.0.1:9999/");
+
     warp::serve(route).run(([127, 0, 0, 1], 9999)).await;
 }

--- a/examples/markdown/src/bin/example_markdown_test_server.rs
+++ b/examples/markdown/src/bin/example_markdown_test_server.rs
@@ -1,5 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
+use warp::reply::with_header;
 use warp::Filter;
 
 // This server is purely to faclitate testing.
@@ -10,14 +11,16 @@ use warp::Filter;
 async fn main() {
     let dir = std::env::args().nth(1).expect("expected a target dir.");
 
-    let route = warp::fs::dir(dir).with(
-        // We need a server that serves the request with cross origin resource sharing.
-        warp::cors()
-            .allow_method("GET")
-            .allow_method("HEAD")
-            .allow_method("OPTIONS")
-            .allow_any_origin(),
-    );
+    let route = warp::fs::dir(dir)
+        .with(
+            // We need a server that serves the request with cross origin resource sharing.
+            warp::cors()
+                .allow_method("GET")
+                .allow_method("HEAD")
+                .allow_method("OPTIONS")
+                .allow_any_origin(),
+        )
+        .map(|m| with_header(m, "cross-origin-resource-policy", "cross-origin"));
 
     println!("Test server is running at: http://127.0.0.1:9999/");
 


### PR DESCRIPTION
This pull request fixes an issue where: 
- gloo-worker tests will fail if test server does not start up before tests are run.
- wasm-bindgen now requires CORP headers.