### PR TITLE
Provides an EventSource implementation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
         ports:
           - 8080:80
       echo_server:
-        image: jmalloc/echo-server@sha256:c461e7e54d947a8777413aaf9c624b4ad1f1bac5d8272475da859ae82c1abd7d
+        image: jmalloc/echo-server@sha256:e43a10c9ecbd025df7ed6dac1e45551ce7bd676142600b0734fe7dcd10a47abe
         ports:
           - 8081:8080
 
@@ -162,7 +162,8 @@ jobs:
       - name: Run browser tests
         env:
           HTTPBIN_URL: "http://localhost:8080"
-          ECHO_SERVER_URL: "ws://localhost:8081"
+          WS_ECHO_SERVER_URL: "ws://localhost:8081"
+          SSE_ECHO_SERVER_URL: "http://localhost:8081/.sse"
         run: |
           cd crates/net
           wasm-pack test --chrome --firefox --headless --all-features
@@ -177,7 +178,8 @@ jobs:
       - name: Run native tests
         env:
           HTTPBIN_URL: "http://localhost:8080"
-          ECHO_SERVER_URL: "ws://localhost:8081"
+          WS_ECHO_SERVER_URL: "ws://localhost:8081"
+          SSE_ECHO_SERVER_URL: "http://localhost:8081/.sse"
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -19,7 +19,6 @@ wasm-bindgen = "0.2"
 web-sys = "0.3"
 js-sys = "0.3"
 gloo-utils = { version = "0.1", path = "../utils", features = ["serde"] }
-gloo-console = { path = "../console" }
 
 wasm-bindgen-futures = "0.4"
 futures-core = { version = "0.3", optional = true }

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -19,6 +19,7 @@ wasm-bindgen = "0.2"
 web-sys = "0.3"
 js-sys = "0.3"
 gloo-utils = { version = "0.1", path = "../utils", features = ["serde"] }
+gloo-console = { path = "../console" }
 
 wasm-bindgen-futures = "0.4"
 futures-core = { version = "0.3", optional = true }
@@ -37,7 +38,7 @@ wasm-bindgen-test = "0.3"
 futures = "0.3"
 
 [features]
-default = ["json", "websocket", "http"]
+default = ["json", "websocket", "http", "eventsource"]
 
 # Enables `.json()` on `Response`
 json = ["serde", "serde_json"]
@@ -78,4 +79,14 @@ http = [
     'web-sys/ReadableStream',
     'web-sys/Blob',
     'web-sys/FormData',
+]
+# Enables the EventSource API
+eventsource = [
+    "futures-channel",
+    "futures-core",
+    "pin-project",
+    'web-sys/Event',
+    'web-sys/EventTarget',
+    'web-sys/EventSource',
+    'web-sys/MessageEvent',
 ]

--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -19,7 +19,7 @@
 <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
 </div>
 
-HTTP requests library for WASM Apps. It provides idiomatic Rust bindings for the `web_sys` `fetch`, `WebSocket` and `EventSource` APIs.
+HTTP requests library for WASM Apps. It provides idiomatic Rust bindings for the `web_sys` [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) and [`EventSource`](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) APIs.
 
 ## Examples
 

--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -19,7 +19,7 @@
 <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
 </div>
 
-HTTP requests library for WASM Apps. It provides idiomatic Rust bindings for the `web_sys` `EventSource`, `fetch` and `WebSocket` APIs.
+HTTP requests library for WASM Apps. It provides idiomatic Rust bindings for the `web_sys` `fetch`, `WebSocket` and `EventSource` APIs.
 
 ## Examples
 
@@ -64,8 +64,8 @@ use wasm_bindgen_futures::spawn_local;
 use futures::StreamExt;
 
 let mut es = EventSource::new("http://api.example.com/ssedemo.php").unwrap();
-es.subscribe_event("some-event-type").unwrap();
-es.subscribe_event("another-event-type").unwrap();
+es.subscribe("some-event-type").unwrap();
+es.subscribe("another-event-type").unwrap();
 
 spawn_local(async move {
     while let Some(Ok((event_type, msg))) = es.next().await {

--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -61,14 +61,15 @@ spawn_local(async move {
 ```rust
 use gloo_net::eventsource::futures::EventSource;
 use wasm_bindgen_futures::spawn_local;
-use futures::StreamExt;
+use futures::{stream, StreamExt};
 
 let mut es = EventSource::new("http://api.example.com/ssedemo.php").unwrap();
-es.subscribe("some-event-type").unwrap();
-es.subscribe("another-event-type").unwrap();
+let stream_1 = es.subscribe("some-event-type").unwrap();
+let stream_2 = es.subscribe("another-event-type").unwrap();
 
 spawn_local(async move {
-    while let Some(Ok((event_type, msg))) = es.next().await {
+    let mut all_streams = stream::select(stream_1, stream_2);
+    while let Some(Ok((event_type, msg))) = all_streams.next().await {
         console_log!(format!("1. {}: {:?}", event_type, msg))
     }
     console_log!("EventSource Closed");

--- a/crates/net/README.md
+++ b/crates/net/README.md
@@ -19,7 +19,7 @@
 <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
 </div>
 
-HTTP requests library for WASM Apps. It provides idiomatic Rust bindings for the `web_sys` `fetch` and `WebSocket` API
+HTTP requests library for WASM Apps. It provides idiomatic Rust bindings for the `web_sys` `EventSource`, `fetch` and `WebSocket` APIs.
 
 ## Examples
 
@@ -53,5 +53,24 @@ spawn_local(async move {
         console_log!(format!("1. {:?}", msg))
     }
     console_log!("WebSocket Closed")
+})
+```
+
+### EventSource
+
+```rust
+use gloo_net::eventsource::futures::EventSource;
+use wasm_bindgen_futures::spawn_local;
+use futures::StreamExt;
+
+let mut es = EventSource::new("http://api.example.com/ssedemo.php").unwrap();
+es.subscribe_event("some-event-type").unwrap();
+es.subscribe_event("another-event-type").unwrap();
+
+spawn_local(async move {
+    while let Some(Ok((event_type, msg))) = es.next().await {
+        console_log!(format!("1. {}: {:?}", event_type, msg))
+    }
+    console_log!("EventSource Closed");
 })
 ```

--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -18,9 +18,9 @@ pub enum Error {
     ),
 }
 
-#[cfg(any(feature = "http", feature = "websocket"))]
+#[cfg(any(feature = "http", feature = "websocket", feature = "eventsource"))]
 pub(crate) use conversion::*;
-#[cfg(any(feature = "http", feature = "websocket"))]
+#[cfg(any(feature = "http", feature = "websocket", feature = "eventsource"))]
 mod conversion {
     use gloo_utils::errors::JsError;
     use std::convert::TryFrom;

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -101,7 +101,7 @@ impl EventSource {
         })
     }
 
-    /// Subscribes to listening for a specific type of event. Can be
+    /// Subscribes to listening for a specific type of event. This method can be
     /// called multiple times. Subscribing again with an event type
     /// that has already been subscribed is benign.
     ///

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -46,8 +46,10 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::MessageEvent;
 
-/// Wrapper around browser's EventSource API.
+/// Wrapper around browser's EventSource API. Dropping
+/// this will close the underlying event source.
 #[allow(missing_debug_implementations)]
+#[derive(Clone)]
 pub struct EventSource {
     es: web_sys::EventSource,
 }

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -22,8 +22,8 @@
 //! # }
 //! # fn no_run() {
 //! let mut es = EventSource::new("http://api.example.com/ssedemo.php").unwrap();
-//! es.subscribe_event("some-event-type").unwrap();
-//! es.subscribe_event("another-event-type").unwrap();
+//! es.subscribe("some-event-type").unwrap();
+//! es.subscribe("another-event-type").unwrap();
 //!
 //! spawn_local(async move {
 //!     while let Some(Ok((event_type, msg))) = es.next().await {
@@ -116,7 +116,7 @@ impl EventSource {
     /// events without an event field as well as events that have the
     /// specific type `event: message`. It will not trigger on any
     /// other event type.
-    pub fn subscribe_event(&mut self, event_type: &str) -> Result<(), JsError> {
+    pub fn subscribe(&mut self, event_type: &str) -> Result<(), JsError> {
         let event_type = event_type.to_string();
         match self.closures.lock() {
             Ok(mut closures) => {
@@ -149,7 +149,7 @@ impl EventSource {
 
     /// Unsubscribes from listening for a specific type of event. Unsubscribing
     /// multiple times is benign.
-    pub fn unsubscribe_event(&mut self, event_type: &str) -> Result<(), JsError> {
+    pub fn unsubscribe(&mut self, event_type: &str) -> Result<(), JsError> {
         match self.closures.lock() {
             Ok(mut closures) => {
                 let (message_callbacks, _) = closures.deref_mut();
@@ -232,13 +232,13 @@ mod tests {
     #[wasm_bindgen_test]
     fn eventsource_works() {
         let mut es = EventSource::new(SSE_ECHO_SERVER_URL).unwrap();
-        es.subscribe_event("server").unwrap();
-        es.subscribe_event("request").unwrap();
+        es.subscribe("server").unwrap();
+        es.subscribe("request").unwrap();
 
         spawn_local(async move {
             assert_eq!(es.next().await.unwrap().unwrap().0, "server");
             assert_eq!(es.next().await.unwrap().unwrap().0, "request");
-            es.unsubscribe_event("request").unwrap();
+            es.unsubscribe("request").unwrap();
         });
     }
 

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -40,10 +40,10 @@ use futures_channel::mpsc;
 use futures_core::{ready, Stream};
 use gloo_utils::errors::JsError;
 use pin_project::{pin_project, pinned_drop};
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::fmt;
 use std::fmt::Formatter;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::MessageEvent;
@@ -110,7 +110,10 @@ impl EventSource {
     /// events without an event field as well as events that have the
     /// specific type `event: message`. It will not trigger on any
     /// other event type.
-    pub fn subscribe(&mut self, event_type: impl Into<String>) -> Result<EventSourceSubscription, JsError> {
+    pub fn subscribe(
+        &mut self,
+        event_type: impl Into<String>,
+    ) -> Result<EventSourceSubscription, JsError> {
         let event_type = event_type.into();
         let (message_sender, message_receiver) = mpsc::unbounded();
 

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -1,0 +1,258 @@
+//! A wrapper around the `EventSource` API using the Futures API to be used with async rust.
+//!
+//! EventSource is similar to WebSocket with the major differences being:
+//!
+//! * they are a one-way stream of server generated events
+//! * their connection is managed entirely by the browser
+//! * their data is slightly more structured including an id, type and data
+//!
+//! EventSource is therefore suitable for simpler scenarios than WebSocket.
+//!
+//! See the [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) to learn more.
+//!
+//! # Example
+//!
+//! ```rust
+//! use gloo_net::eventsource::futures::EventSource;
+//! use wasm_bindgen_futures::spawn_local;
+//! use futures::StreamExt;
+//!
+//! # macro_rules! console_log {
+//! #    ($($expr:expr),*) => {{}};
+//! # }
+//! # fn no_run() {
+//! let mut es = EventSource::new("http://api.example.com/ssedemo.php").unwrap();
+//! es.subscribe_event("some-event-type").unwrap();
+//! es.subscribe_event("another-event-type").unwrap();
+//!
+//! spawn_local(async move {
+//!     while let Some(Ok((event_type, msg))) = es.next().await {
+//!         console_log!(format!("1. {}: {:?}", event_type, msg))
+//!     }
+//!     console_log!("EventSource Closed");
+//! })
+//! # }
+//! ```
+use crate::eventsource::{EventSourceError, State};
+use crate::js_to_js_error;
+use futures_channel::mpsc;
+use futures_core::{ready, Stream};
+use gloo_utils::errors::JsError;
+use pin_project::{pin_project, pinned_drop};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::ops::DerefMut;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
+use web_sys::MessageEvent;
+
+/// Wrapper around browser's EventSource API.
+#[allow(missing_debug_implementations)]
+#[pin_project(PinnedDrop)]
+pub struct EventSource {
+    es: web_sys::EventSource,
+    message_sender: mpsc::UnboundedSender<StreamMessage>,
+    #[pin]
+    message_receiver: mpsc::UnboundedReceiver<StreamMessage>,
+    #[allow(clippy::type_complexity)]
+    closures: Arc<
+        Mutex<(
+            HashMap<String, Closure<dyn FnMut(MessageEvent)>>,
+            Closure<dyn FnMut(web_sys::Event)>,
+        )>,
+    >,
+}
+
+impl EventSource {
+    /// Establish an EventSource.
+    ///
+    /// This function may error in the following cases:
+    /// - The connection url is invalid
+    ///
+    /// The error returned is [`JsError`]. See the
+    /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/EventSource#exceptions_thrown)
+    /// to learn more.
+    pub fn new(url: &str) -> Result<Self, JsError> {
+        let es = web_sys::EventSource::new(url).map_err(js_to_js_error)?;
+
+        let (message_sender, message_receiver) = mpsc::unbounded();
+
+        let error_callback: Closure<dyn FnMut(web_sys::Event)> = {
+            let sender = message_sender.clone();
+            Closure::wrap(Box::new(move |e: web_sys::Event| {
+                let sender = sender.clone();
+                let is_connecting = e
+                    .current_target()
+                    .and_then(|target| target.dyn_into::<web_sys::EventSource>().ok())
+                    .map(|es| es.ready_state() == web_sys::EventSource::CONNECTING)
+                    .unwrap_or(false);
+                if !is_connecting {
+                    let _ = sender.unbounded_send(StreamMessage::ErrorEvent);
+                };
+            }) as Box<dyn FnMut(web_sys::Event)>)
+        };
+
+        es.set_onerror(Some(error_callback.as_ref().unchecked_ref()));
+
+        Ok(Self {
+            es,
+            message_sender,
+            message_receiver,
+            closures: Arc::new(Mutex::new((HashMap::new(), error_callback))),
+        })
+    }
+
+    /// Subscribes to listening for a specific type of event. Can be
+    /// called multiple times. Subscribing again with an event type
+    /// that has already been subscribed is benign.
+    ///
+    /// All event types are streamed back with the element of the stream
+    /// being a tuple of event type and message event.
+    ///
+    /// The event type of "message" is a special case, as it will capture
+    /// events without an event field as well as events that have the
+    /// specific type `event: message`. It will not trigger on any
+    /// other event type.
+    pub fn subscribe_event(&mut self, event_type: &str) -> Result<(), JsError> {
+        let event_type = event_type.to_string();
+        match self.closures.lock() {
+            Ok(mut closures) => {
+                let (message_callbacks, _) = closures.deref_mut();
+
+                if let Entry::Vacant(entry) = message_callbacks.entry(event_type.clone()) {
+                    let message_callback: Closure<dyn FnMut(MessageEvent)> = {
+                        let sender = self.message_sender.clone();
+                        Closure::wrap(Box::new(move |e: MessageEvent| {
+                            let sender = sender.clone();
+                            let event_type = event_type.clone();
+                            let _ = sender.unbounded_send(StreamMessage::Message(event_type, e));
+                        }) as Box<dyn FnMut(MessageEvent)>)
+                    };
+
+                    self.es
+                        .add_event_listener_with_callback(
+                            entry.key(),
+                            message_callback.as_ref().unchecked_ref(),
+                        )
+                        .map_err(js_to_js_error)?;
+
+                    entry.insert(message_callback);
+                }
+                Ok(())
+            }
+            Err(e) => Err(js_sys::Error::new(&format!("Failed to subscribe: {}", e)).into()),
+        }
+    }
+
+    /// Unsubscribes from listening for a specific type of event. Unsubscribing
+    /// multiple times is benign.
+    pub fn unsubscribe_event(&mut self, event_type: &str) -> Result<(), JsError> {
+        match self.closures.lock() {
+            Ok(mut closures) => {
+                let (message_callbacks, _) = closures.deref_mut();
+
+                if let Some(message_callback) = message_callbacks.remove(event_type) {
+                    self.es
+                        .remove_event_listener_with_callback(
+                            event_type,
+                            message_callback.as_ref().unchecked_ref(),
+                        )
+                        .map_err(js_to_js_error)?;
+                }
+                Ok(())
+            }
+            Err(e) => Err(js_sys::Error::new(&format!("Failed to subscribe: {}", e)).into()),
+        }
+    }
+
+    /// Closes the EventSource.
+    ///
+    /// See the [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/close#parameters)
+    /// to learn about this function
+    pub fn close(self) {
+        self.es.close();
+    }
+
+    /// The current state of the EventSource.
+    pub fn state(&self) -> State {
+        let ready_state = self.es.ready_state();
+        match ready_state {
+            0 => State::Connecting,
+            1 => State::Open,
+            2 => State::Closed,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Clone)]
+enum StreamMessage {
+    ErrorEvent,
+    Message(String, MessageEvent),
+}
+
+impl Stream for EventSource {
+    type Item = Result<(String, MessageEvent), EventSourceError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let msg = ready!(self.project().message_receiver.poll_next(cx));
+        match msg {
+            Some(StreamMessage::Message(event_type, msg)) => {
+                Poll::Ready(Some(Ok((event_type, msg))))
+            }
+            Some(StreamMessage::ErrorEvent) => {
+                Poll::Ready(Some(Err(EventSourceError::ConnectionError)))
+            }
+            None => Poll::Ready(None),
+        }
+    }
+}
+
+#[pinned_drop]
+impl PinnedDrop for EventSource {
+    fn drop(self: Pin<&mut Self>) {
+        self.es.close();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+    use wasm_bindgen_futures::spawn_local;
+    use wasm_bindgen_test::*;
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    const SSE_ECHO_SERVER_URL: &str = env!("SSE_ECHO_SERVER_URL");
+
+    #[wasm_bindgen_test]
+    fn eventsource_works() {
+        let mut es = EventSource::new(SSE_ECHO_SERVER_URL).unwrap();
+        es.subscribe_event("server").unwrap();
+        es.subscribe_event("request").unwrap();
+
+        spawn_local(async move {
+            assert_eq!(es.next().await.unwrap().unwrap().0, "server");
+            assert_eq!(es.next().await.unwrap().unwrap().0, "request");
+            es.unsubscribe_event("request").unwrap();
+        });
+    }
+
+    #[wasm_bindgen_test]
+    fn eventsource_close_works() {
+        let mut es = EventSource::new("rubbish").unwrap();
+
+        spawn_local(async move {
+            // we should expect an immediate failure
+
+            assert_eq!(
+                es.next().await,
+                Some(Err(EventSourceError::ConnectionError))
+            );
+        })
+    }
+}

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -229,7 +229,7 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn eventsource_close_works() {
+    fn eventsource_connect_failure_works() {
         let mut es = EventSource::new("rubbish").unwrap();
 
         spawn_local(async move {

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -82,7 +82,7 @@ impl EventSource {
                 let sender = sender.clone();
                 let is_connecting = e
                     .current_target()
-                    .and_then(|target| target.dyn_into::<web_sys::EventSource>().ok())
+                    .map(|target| target.unchecked_into::<web_sys::EventSource>())
                     .map(|es| es.ready_state() == web_sys::EventSource::CONNECTING)
                     .unwrap_or(false);
                 if !is_connecting {

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -128,7 +128,7 @@ impl EventSource {
 
         self.es
             .add_event_listener_with_callback("error", error_callback.as_ref().unchecked_ref())
-            .unwrap();
+            .map_err(js_to_js_error)?;
 
         Ok(EventSourceSubscription {
             error_callback,

--- a/crates/net/src/eventsource/mod.rs
+++ b/crates/net/src/eventsource/mod.rs
@@ -1,0 +1,38 @@
+//! Wrapper around the `EventSource` API
+//!
+//! This API is provided in the following flavors:
+//! - [Futures API][futures]
+
+pub mod futures;
+
+use std::fmt;
+
+/// The state of the EventSource.
+///
+/// See [`EventSource.readyState` on MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/readyState)
+/// to learn more.
+#[derive(Copy, Clone, Debug)]
+pub enum State {
+    /// The connection has not yet been established.
+    Connecting,
+    /// The EventSource connection is established and communication is possible.
+    Open,
+    /// The connection has been closed or could not be opened.
+    Closed,
+}
+
+/// Error returned by the EventSource
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum EventSourceError {
+    /// The `error` event
+    ConnectionError,
+}
+
+impl fmt::Display for EventSourceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EventSourceError::ConnectionError => write!(f, "EventSource connection failed"),
+        }
+    }
+}

--- a/crates/net/src/eventsource/mod.rs
+++ b/crates/net/src/eventsource/mod.rs
@@ -22,8 +22,9 @@ pub enum State {
 }
 
 /// Error returned by the EventSource
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[non_exhaustive]
+#[allow(missing_copy_implementations)]
 pub enum EventSourceError {
     /// The `error` event
     ConnectionError,

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -11,6 +11,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod error;
+#[cfg(feature = "eventsource")]
+#[cfg_attr(docsrs, doc(cfg(feature = "eventsource")))]
+pub mod eventsource;
 #[cfg(feature = "http")]
 #[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub mod http;

--- a/crates/net/src/websocket/futures.rs
+++ b/crates/net/src/websocket/futures.rs
@@ -313,11 +313,11 @@ mod tests {
 
     wasm_bindgen_test_configure!(run_in_browser);
 
-    const ECHO_SERVER_URL: &str = env!("ECHO_SERVER_URL");
+    const WS_ECHO_SERVER_URL: &str = env!("WS_ECHO_SERVER_URL");
 
     #[wasm_bindgen_test]
     fn websocket_works() {
-        let ws = WebSocket::open(ECHO_SERVER_URL).unwrap();
+        let ws = WebSocket::open(WS_ECHO_SERVER_URL).unwrap();
         let (mut sender, mut receiver) = ws.split();
 
         spawn_local(async move {
@@ -333,8 +333,8 @@ mod tests {
 
         spawn_local(async move {
             // ignore first message
-            // the echo-server used sends it's info in the first message
-            // let _ = ws.next().await;
+            // the echo-server uses it to send it's info in the first message
+            let _ = receiver.next().await;
 
             assert_eq!(
                 receiver.next().await.unwrap().unwrap(),


### PR DESCRIPTION
Inspired by the WebSocket API.

Example usage:

```rust
use gloo_net::eventsource::futures::EventSource;
use wasm_bindgen_futures::spawn_local;
use futures::{stream, StreamExt};

let mut es = EventSource::new("http://api.example.com/ssedemo.php").unwrap();
let stream_1 = es.subscribe("some-event-type").unwrap();
let stream_2 = es.subscribe("another-event-type").unwrap();

spawn_local(async move {
    let mut all_streams = stream::select(stream_1, stream_2);
    while let Some(Ok((event_type, msg))) = all_streams.next().await {
        console_log!(format!("1. {}: {:?}", event_type, msg))
    }
    console_log!("EventSource Closed");
})
```

TODO:

* [x] Find/build an EventSource endpoint for testing
* [x] Test from within my real-world application

Fixes https://github.com/hamza1311/reqwasm/issues/8
Fixes https://github.com/rustwasm/gloo/issues/8