### PR TITLE
Work around firefox webextensions bug

### DIFF
--- a/crates/timers/src/callback.rs
+++ b/crates/timers/src/callback.rs
@@ -6,16 +6,16 @@ use wasm_bindgen::{JsCast, JsValue};
 
 #[wasm_bindgen]
 extern "C" {
-    #[wasm_bindgen(js_name = "setTimeout", catch)]
+    #[wasm_bindgen(js_name = "setTimeout", js_namespace = window, catch)]
     fn set_timeout(handler: &Function, timeout: i32) -> Result<i32, JsValue>;
 
-    #[wasm_bindgen(js_name = "setInterval", catch)]
+    #[wasm_bindgen(js_name = "setInterval", js_namespace = window, catch)]
     fn set_interval(handler: &Function, timeout: i32) -> Result<i32, JsValue>;
 
-    #[wasm_bindgen(js_name = "clearTimeout")]
+    #[wasm_bindgen(js_name = "clearTimeout", js_namespace = window)]
     fn clear_timeout(handle: i32);
 
-    #[wasm_bindgen(js_name = "clearInterval")]
+    #[wasm_bindgen(js_name = "clearInterval", js_namespace = window)]
     fn clear_interval(handle: i32);
 }
 


### PR DESCRIPTION
Importing `gloo_timers` in firefox webextension's content script results in an error: `LinkError: import object field '__wbg_clearTimeout_65417660fe82f08d' is not a Function`

It actually seems to be a firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1787770

This can simply be worked around by refering to timer functions using window object (setInterval -> window.setInterval) which this PR does. I do not think this would impact users outside of webextensions in any way, as window.setInterval and setInterval are the same functions in usual context (but apparently not in content scripts...)