### PR TITLE
Add std::error::Error impl for WebSocketError

### DIFF
--- a/crates/net/src/websocket/mod.rs
+++ b/crates/net/src/websocket/mod.rs
@@ -61,3 +61,5 @@ impl fmt::Display for WebSocketError {
         }
     }
 }
+
+impl std::error::Error for WebSocketError {}


### PR DESCRIPTION
Adds an `std::error::Error` implementation for `gloo_net::websocket::WebSocketError`.