### PR TITLE
Fix history tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,15 +109,18 @@ jobs:
             cargo-${{ runner.os }}-test-worker-
             cargo-${{ runner.os }}-
 
-      - name: Run tests for gloo worker
+      - name: Build and Run Test Server
+        run: |
+          cargo build -p example-markdown --bin example_markdown_test_server
+          nohup target/debug/example_markdown_test_server examples/markdown/dist &
+
+      - name: Build Test Worker
         run: |
           trunk build examples/markdown/index.html
-          cargo build -p example-markdown --bin example_markdown_test_server
 
-          nohup target/debug/example_markdown_test_server examples/markdown/dist &
-          sleep 5
-
-          wasm-pack test --headless --firefox --chrome examples/markdown
+      - name: Run tests for gloo worker
+        run: |
+          wasm-pack test --headless --firefox examples/markdown
 
 
   test-net:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,8 +76,6 @@ jobs:
             wasm-pack test --headless --firefox --chrome crates/$x --no-default-features
           done
 
-
-
   test-worker:
     name: Test gloo-worker
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Run tests for gloo worker
         run: |
-          wasm-pack test --headless --firefox examples/markdown
+          wasm-pack test --headless --firefox --chrome  examples/markdown
 
 
   test-net:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,10 @@ jobs:
       - name: Run tests for gloo worker
         run: |
           trunk build examples/markdown/index.html
-          nohup cargo run -p example-markdown --bin example_markdown_test_server -- examples/markdown/dist &
+          cargo build -p example-markdown --bin example_markdown_test_server
+
+          nohup target/debug/example_markdown_test_server examples/markdown/dist &
+          sleep 2
 
           wasm-pack test --headless --firefox --chrome examples/markdown
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,13 +76,46 @@ jobs:
             wasm-pack test --headless --firefox --chrome crates/$x --no-default-features
           done
 
+
+
+  test-worker:
+    name: Test gloo-worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          profile: minimal
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Setup trunk
+        uses: jetli/trunk-action@v0.1.0
+        with:
+          version: 'latest'
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-browser-tests-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-test-worker-
+            cargo-${{ runner.os }}-
+
       - name: Run tests for gloo worker
         run: |
           trunk build examples/markdown/index.html
           cargo build -p example-markdown --bin example_markdown_test_server
 
           nohup target/debug/example_markdown_test_server examples/markdown/dist &
-          sleep 2
+          sleep 5
 
           wasm-pack test --headless --firefox --chrome examples/markdown
 

--- a/crates/file/src/blob.rs
+++ b/crates/file/src/blob.rs
@@ -62,7 +62,7 @@ impl BlobContents for Blob {
 ///
 /// `Blob`s can be created directly from `&str`, `&[u8]`, and `js_sys::ArrayBuffer`s using the
 /// `Blob::new` or `Blob::new_with_options` functions.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Blob {
     inner: web_sys::Blob,
 }
@@ -159,7 +159,7 @@ impl AsRef<JsValue> for Blob {
 }
 
 /// A [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File).
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct File {
     // the trick here is that we know the contents of `inner` are a file, even though that type
     // information is not stored. It is the same trick as is used in `web_sys`.

--- a/crates/file/src/file_list.rs
+++ b/crates/file/src/file_list.rs
@@ -2,7 +2,7 @@ use crate::blob::File;
 use wasm_bindgen::prelude::*;
 
 /// A list of files, for example from an `<input type="file">`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileList {
     inner: Vec<File>,
 }

--- a/crates/history/tests/browser_history.rs
+++ b/crates/history/tests/browser_history.rs
@@ -1,30 +1,45 @@
-use std::time::Duration;
-
-use gloo_timers::future::sleep;
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
 use gloo_history::{BrowserHistory, History};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
+mod utils;
+use utils::delayed_assert_eq;
+
 #[test]
 async fn history_works() {
     let history = BrowserHistory::new();
-    assert_eq!(history.location().path(), "/");
+    {
+        let history = history.clone();
+        delayed_assert_eq(move || history.location().path().to_owned(), || "/").await;
+    }
 
     history.push("/path-a");
-    sleep(Duration::from_millis(200)).await;
-    assert_eq!(history.location().path(), "/path-a");
+
+    {
+        let history = history.clone();
+        delayed_assert_eq(move || history.location().path().to_owned(), || "/path-a").await;
+    }
 
     history.replace("/path-b");
-    sleep(Duration::from_millis(200)).await;
-    assert_eq!(history.location().path(), "/path-b");
+
+    {
+        let history = history.clone();
+        delayed_assert_eq(move || history.location().path().to_owned(), || "/path-b").await;
+    }
 
     history.back();
-    sleep(Duration::from_millis(200)).await;
-    assert_eq!(history.location().path(), "/");
+
+    {
+        let history = history.clone();
+        delayed_assert_eq(move || history.location().path().to_owned(), || "/").await;
+    }
 
     history.forward();
-    sleep(Duration::from_millis(200)).await;
-    assert_eq!(history.location().path(), "/path-b");
+
+    {
+        let history = history.clone();
+        delayed_assert_eq(move || history.location().path().to_owned(), || "/path-b").await;
+    }
 }

--- a/crates/history/tests/hash_history.rs
+++ b/crates/history/tests/hash_history.rs
@@ -1,6 +1,3 @@
-use std::time::Duration;
-
-use gloo_timers::future::sleep;
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
 use gloo_history::{HashHistory, History};

--- a/crates/history/tests/hash_history.rs
+++ b/crates/history/tests/hash_history.rs
@@ -8,32 +8,49 @@ use gloo_utils::window;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
+mod utils;
+use utils::delayed_assert_eq;
+
 #[test]
 async fn history_works() {
     let history = HashHistory::new();
-    assert_eq!(history.location().path(), "/");
-    assert_eq!(window().location().pathname().unwrap(), "/");
-    assert_eq!(window().location().hash().unwrap(), "#/");
+
+    {
+        let history = history.clone();
+        delayed_assert_eq(|| history.location().path().to_owned(), || "/").await;
+    }
+    delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+    delayed_assert_eq(|| window().location().hash().unwrap(), || "#/").await;
 
     history.push("/path-a");
-    assert_eq!(history.location().path(), "/path-a");
-    assert_eq!(window().location().pathname().unwrap(), "/");
-    assert_eq!(window().location().hash().unwrap(), "#/path-a");
+    {
+        let history = history.clone();
+        delayed_assert_eq(|| history.location().path().to_owned(), || "/path-a").await;
+    }
+    delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+    delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-a").await;
 
     history.replace("/path-b");
-    assert_eq!(history.location().path(), "/path-b");
-    assert_eq!(window().location().pathname().unwrap(), "/");
-    assert_eq!(window().location().hash().unwrap(), "#/path-b");
+    {
+        let history = history.clone();
+        delayed_assert_eq(|| history.location().path().to_owned(), || "/path-b").await;
+    }
+    delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+    delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-b").await;
 
     history.back();
-    sleep(Duration::from_millis(100)).await;
-    assert_eq!(history.location().path(), "/");
-    assert_eq!(window().location().pathname().unwrap(), "/");
-    assert_eq!(window().location().hash().unwrap(), "#/");
+    {
+        let history = history.clone();
+        delayed_assert_eq(|| history.location().path().to_owned(), || "/").await;
+    }
+    delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+    delayed_assert_eq(|| window().location().hash().unwrap(), || "#/").await;
 
     history.forward();
-    sleep(Duration::from_millis(100)).await;
-    assert_eq!(history.location().path(), "/path-b");
-    assert_eq!(window().location().pathname().unwrap(), "/");
-    assert_eq!(window().location().hash().unwrap(), "#/path-b");
+    {
+        let history = history.clone();
+        delayed_assert_eq(|| history.location().path().to_owned(), || "/path-b").await;
+    }
+    delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+    delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-b").await;
 }

--- a/crates/history/tests/hash_history_feat_serialize.rs
+++ b/crates/history/tests/hash_history_feat_serialize.rs
@@ -3,17 +3,22 @@ use wasm_bindgen_test::wasm_bindgen_test_configure;
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[cfg(all(feature = "query"))]
+mod utils;
+
+#[cfg(all(feature = "query"))]
 mod feat_serialize {
+    use super::*;
+
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
+    use utils::delayed_assert_eq;
+
     use std::rc::Rc;
-    use std::time::Duration;
 
     use serde::{Deserialize, Serialize};
 
     use gloo_history::{HashHistory, History};
 
-    use gloo_timers::future::sleep;
     use gloo_utils::window;
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -31,29 +36,42 @@ mod feat_serialize {
     #[test]
     async fn history_serialize_works() {
         let history = HashHistory::new();
-        assert_eq!(history.location().path(), "/");
+        {
+            let history = history.clone();
+            delayed_assert_eq(move || history.location().path().to_owned(), || "/").await;
+        }
 
         history.push("/path-a");
-        assert_eq!(history.location().path(), "/path-a");
-        assert_eq!(window().location().pathname().unwrap(), "/");
-        assert_eq!(window().location().hash().unwrap(), "#/path-a");
+        {
+            let history = history.clone();
+            delayed_assert_eq(|| history.location().path().to_owned(), || "/path-a").await;
+        }
+        delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+        delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-a").await;
 
         history.replace("/path-b");
-        assert_eq!(history.location().path(), "/path-b");
-        assert_eq!(window().location().pathname().unwrap(), "/");
-        assert_eq!(window().location().hash().unwrap(), "#/path-b");
+        {
+            let history = history.clone();
+            delayed_assert_eq(|| history.location().path().to_owned(), || "/path-b").await;
+        }
+        delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+        delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-b").await;
 
         history.back();
-        sleep(Duration::from_millis(200)).await;
-        assert_eq!(history.location().path(), "/");
-        assert_eq!(window().location().pathname().unwrap(), "/");
-        assert_eq!(window().location().hash().unwrap(), "#/");
+        {
+            let history = history.clone();
+            delayed_assert_eq(|| history.location().path().to_owned(), || "/").await;
+        }
+        delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+        delayed_assert_eq(|| window().location().hash().unwrap(), || "#/").await;
 
         history.forward();
-        sleep(Duration::from_millis(200)).await;
-        assert_eq!(history.location().path(), "/path-b");
-        assert_eq!(window().location().pathname().unwrap(), "/");
-        assert_eq!(window().location().hash().unwrap(), "#/path-b");
+        {
+            let history = history.clone();
+            delayed_assert_eq(|| history.location().path().to_owned(), || "/path-b").await;
+        }
+        delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+        delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-b").await;
 
         history
             .push_with_query(
@@ -65,20 +83,35 @@ mod feat_serialize {
             )
             .unwrap();
 
-        assert_eq!(history.location().path(), "/path");
-        assert_eq!(history.location().query_str(), "?a=something&b=123");
-        assert_eq!(window().location().pathname().unwrap(), "/");
-        assert_eq!(
-            window().location().hash().unwrap(),
-            "#/path?a=something&b=123"
-        );
-        assert_eq!(
-            history.location().query::<Query>().unwrap(),
-            Query {
-                a: "something".to_string(),
-                b: 123,
-            }
-        );
+        {
+            let history = history.clone();
+            delayed_assert_eq(|| history.location().path().to_owned(), || "/path").await;
+        }
+        delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+        delayed_assert_eq(
+            || window().location().hash().unwrap(),
+            || "#/path?a=something&b=123",
+        )
+        .await;
+        {
+            let history = history.clone();
+            delayed_assert_eq(
+                || history.location().query_str().to_owned(),
+                || "?a=something&b=123",
+            )
+            .await;
+        }
+        {
+            let history = history.clone();
+            delayed_assert_eq(
+                || history.location().query::<Query>().unwrap(),
+                || Query {
+                    a: "something".to_string(),
+                    b: 123,
+                },
+            )
+            .await;
+        }
 
         history.push_with_state(
             "/path-c",
@@ -88,15 +121,24 @@ mod feat_serialize {
             },
         );
 
-        assert_eq!(history.location().path(), "/path-c");
-        assert_eq!(window().location().pathname().unwrap(), "/");
-        assert_eq!(window().location().hash().unwrap(), "#/path-c");
-        assert_eq!(
-            history.location().state::<State>().unwrap(),
-            Rc::new(State {
-                i: "something".to_string(),
-                ii: 123,
-            })
-        );
+        {
+            let history = history.clone();
+            delayed_assert_eq(|| history.location().path().to_owned(), || "/path-c").await;
+        }
+        delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
+        delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-c").await;
+        {
+            let history = history.clone();
+            delayed_assert_eq(
+                || history.location().state::<State>().unwrap(),
+                || {
+                    Rc::new(State {
+                        i: "something".to_string(),
+                        ii: 123,
+                    })
+                },
+            )
+            .await;
+        }
     }
 }

--- a/crates/history/tests/utils.rs
+++ b/crates/history/tests/utils.rs
@@ -1,0 +1,25 @@
+use gloo_timers::future::sleep;
+use std::fmt::Debug;
+use std::time::Duration;
+
+pub async fn delayed_assert_eq<FL, L, FR, R>(left: FL, right: FR)
+where
+    FL: Fn() -> L,
+    FR: Fn() -> R,
+    L: PartialEq<R>,
+    L: Debug,
+    R: Debug,
+{
+    'outer: for i in 0..2 {
+        if i > 0 {
+            assert_eq!(left(), right());
+        }
+
+        for _ in 0..100 {
+            sleep(Duration::from_millis(10)).await;
+            if left() == right() {
+                break 'outer;
+            }
+        }
+    }
+}

--- a/examples/markdown/src/bin/example_markdown_test_server.rs
+++ b/examples/markdown/src/bin/example_markdown_test_server.rs
@@ -19,5 +19,7 @@ async fn main() {
             .allow_any_origin(),
     );
 
+    println!("Test server is running at: http://127.0.0.1:9999/");
+
     warp::serve(route).run(([127, 0, 0, 1], 9999)).await;
 }

--- a/examples/markdown/src/bin/example_markdown_test_server.rs
+++ b/examples/markdown/src/bin/example_markdown_test_server.rs
@@ -1,5 +1,6 @@
 #![cfg(not(target_arch = "wasm32"))]
 
+use warp::reply::with_header;
 use warp::Filter;
 
 // This server is purely to faclitate testing.
@@ -10,14 +11,16 @@ use warp::Filter;
 async fn main() {
     let dir = std::env::args().nth(1).expect("expected a target dir.");
 
-    let route = warp::fs::dir(dir).with(
-        // We need a server that serves the request with cross origin resource sharing.
-        warp::cors()
-            .allow_method("GET")
-            .allow_method("HEAD")
-            .allow_method("OPTIONS")
-            .allow_any_origin(),
-    );
+    let route = warp::fs::dir(dir)
+        .with(
+            // We need a server that serves the request with cross origin resource sharing.
+            warp::cors()
+                .allow_method("GET")
+                .allow_method("HEAD")
+                .allow_method("OPTIONS")
+                .allow_any_origin(),
+        )
+        .map(|m| with_header(m, "cross-origin-resource-policy", "cross-origin"));
 
     println!("Test server is running at: http://127.0.0.1:9999/");
 


### PR DESCRIPTION
This pull request addresses random test failures of `gloo-history` by implementing an automatic retry strategy that usually presents in modern browser testing framework (cypress / playwright).