### PR TITLE
Gloo net fetch in worker

### DIFF
--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -78,6 +78,7 @@ http = [
     'web-sys/ReadableStream',
     'web-sys/Blob',
     'web-sys/FormData',
+    'web-sys/DedicatedWorkerGlobalScope',
 ]
 # Enables the EventSource API
 eventsource = [

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -78,7 +78,7 @@ http = [
     'web-sys/ReadableStream',
     'web-sys/Blob',
     'web-sys/FormData',
-    'web-sys/DedicatedWorkerGlobalScope',
+    'web-sys/WorkerGlobalScope',
 ]
 # Enables the EventSource API
 eventsource = [

--- a/crates/net/src/error.rs
+++ b/crates/net/src/error.rs
@@ -16,6 +16,9 @@ pub enum Error {
         #[from]
         serde_json::Error,
     ),
+    /// Error returned by this crate
+    #[error("{0}")]
+    GlooError(String),
 }
 
 #[cfg(any(feature = "http", feature = "websocket", feature = "eventsource"))]

--- a/crates/net/src/http/mod.rs
+++ b/crates/net/src/http/mod.rs
@@ -264,18 +264,13 @@ impl Request {
             let window = global.dyn_into::<web_sys::Window>().unwrap();
             window.fetch_with_request(&request)
         } else {
-            let maybe_worker =
-                Reflect::get(&global, &JsValue::from_str("DedicatedWorkerGlobalScope"))
-                    .map_err(js_to_error)?;
+            let maybe_worker = Reflect::get(&global, &JsValue::from_str("WorkerGlobalScope"))
+                .map_err(js_to_error)?;
             if !maybe_worker.is_undefined() {
-                let worker = global
-                    .dyn_into::<web_sys::DedicatedWorkerGlobalScope>()
-                    .unwrap();
+                let worker = global.dyn_into::<web_sys::WorkerGlobalScope>().unwrap();
                 worker.fetch_with_request(&request)
             } else {
-                return Err(Error::GlooError(
-                    "Unsupported JavaScript global context".into(),
-                ));
+                panic!("Unsupported JavaScript global context");
             }
         };
 

--- a/crates/net/src/http/mod.rs
+++ b/crates/net/src/http/mod.rs
@@ -17,6 +17,7 @@ mod headers;
 mod query;
 
 use crate::{js_to_error, Error};
+use js_sys::Reflect;
 use js_sys::{ArrayBuffer, Uint8Array};
 use std::fmt;
 use wasm_bindgen::prelude::*;
@@ -256,7 +257,28 @@ impl Request {
         let request =
             web_sys::Request::new_with_str_and_init(&url, &self.options).map_err(js_to_error)?;
 
-        let promise = gloo_utils::window().fetch_with_request(&request);
+        let global = js_sys::global();
+        let maybe_window =
+            Reflect::get(&global, &JsValue::from_str("Window")).map_err(js_to_error)?;
+        let promise = if !maybe_window.is_undefined() {
+            let window = global.dyn_into::<web_sys::Window>().unwrap();
+            window.fetch_with_request(&request)
+        } else {
+            let maybe_worker =
+                Reflect::get(&global, &JsValue::from_str("DedicatedWorkerGlobalScope"))
+                    .map_err(js_to_error)?;
+            if !maybe_worker.is_undefined() {
+                let worker = global
+                    .dyn_into::<web_sys::DedicatedWorkerGlobalScope>()
+                    .unwrap();
+                worker.fetch_with_request(&request)
+            } else {
+                return Err(Error::GlooError(
+                    "Unsupported JavaScript global context".into(),
+                ));
+            }
+        };
+
         let response = JsFuture::from(promise).await.map_err(js_to_error)?;
         match response.dyn_into::<web_sys::Response>() {
             Ok(response) => Ok(Response {


### PR DESCRIPTION
I'm trying to use `gloo-net` in a web extension with manifest V3 but this does not work because of #201.
Fortunately @cdata [found a workaround](https://github.com/cdata/gloo/commit/b23035decc9ce41f40680d52ac7b85add0d00104) :smiley:
That at least avoids a panic but my service worker of the web extension does not have the `DedicadedWorkerGlobalScope` so I changed it to `WorkerGlobalScope` because as far as I know a `DedicadedWorkerGlobalScope` is a specialization of `WorkerGlobalScope`.

What do you think?