### PR TITLE
fix: cyclic dependency for gloo-net websocket feature

### DIFF
--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 wasm-bindgen = "0.2"
 web-sys = "0.3"
 js-sys = "0.3"
-gloo-utils = { version = "0.1", path = "../utils", features = ["serde"] }
+gloo-utils = { version = "0.1", path = "../utils", default-features = false }
 
 wasm-bindgen-futures = "0.4"
 futures-core = { version = "0.3", optional = true }
@@ -26,7 +26,7 @@ futures-sink = { version = "0.3", optional = true }
 
 thiserror = "1.0"
 
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 
 futures-channel = { version = "0.3", optional = true }
@@ -35,12 +35,13 @@ pin-project = { version = "1.0", optional = true }
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 futures = "0.3"
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 default = ["json", "websocket", "http", "eventsource"]
 
 # Enables `.json()` on `Response`
-json = ["serde", "serde_json"]
+json = ["serde", "serde_json", "gloo-utils/serde"]
 # Enables the WebSocket API
 websocket = [
     'web-sys/WebSocket',
@@ -52,11 +53,9 @@ websocket = [
     'web-sys/BinaryType',
     'web-sys/Blob',
     "futures-channel",
-    "pin-project",
     "futures-core",
     "futures-sink",
-    "wasm-bindgen/serde-serialize",
-    "serde",
+    "pin-project",
 ]
 # Enables the HTTP API
 http = [


### PR DESCRIPTION
* remove the deprecated `wasm-bindgen/serde-serialize`
* mark `gloo-utils/serde` optional under `json`
* enable `serde/derive` only for testing