### PR TITLE
fix(ws): calling close event with destroyed close callback

### DIFF
--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -44,11 +44,13 @@ json = ["serde", "serde_json"]
 # Enables the WebSocket API
 websocket = [
     'web-sys/WebSocket',
+    'web-sys/AddEventListenerOptions',
     'web-sys/ErrorEvent',
     'web-sys/FileReader',
     'web-sys/MessageEvent',
     'web-sys/ProgressEvent',
     'web-sys/CloseEvent',
+    'web-sys/CloseEventInit',
     'web-sys/BinaryType',
     'web-sys/Blob',
     "futures-channel",

--- a/crates/net/src/websocket/futures.rs
+++ b/crates/net/src/websocket/futures.rs
@@ -136,7 +136,12 @@ impl WebSocket {
             }) as Box<dyn FnMut()>)
         };
 
-        ws.set_onopen(Some(open_callback.as_ref().unchecked_ref()));
+        ws.add_event_listener_with_callback_and_add_event_listener_options(
+            "open",
+            open_callback.as_ref().unchecked_ref(),
+            web_sys::AddEventListenerOptions::new().once(true),
+        )
+        .map_err(js_to_js_error)?;
 
         let message_callback: Closure<dyn FnMut(MessageEvent)> = {
             let sender = sender.clone();
@@ -146,7 +151,8 @@ impl WebSocket {
             }) as Box<dyn FnMut(MessageEvent)>)
         };
 
-        ws.set_onmessage(Some(message_callback.as_ref().unchecked_ref()));
+        ws.add_event_listener_with_callback("message", message_callback.as_ref().unchecked_ref())
+            .map_err(js_to_js_error)?;
 
         let error_callback: Closure<dyn FnMut(web_sys::Event)> = {
             let sender = sender.clone();
@@ -155,7 +161,8 @@ impl WebSocket {
             }) as Box<dyn FnMut(web_sys::Event)>)
         };
 
-        ws.set_onerror(Some(error_callback.as_ref().unchecked_ref()));
+        ws.add_event_listener_with_callback("error", error_callback.as_ref().unchecked_ref())
+            .map_err(js_to_js_error)?;
 
         let close_callback: Closure<dyn FnMut(web_sys::CloseEvent)> = {
             let sender = sender.clone();
@@ -170,7 +177,12 @@ impl WebSocket {
             }) as Box<dyn FnMut(web_sys::CloseEvent)>)
         };
 
-        ws.set_onclose(Some(close_callback.as_ref().unchecked_ref()));
+        ws.add_event_listener_with_callback_and_add_event_listener_options(
+            "close",
+            close_callback.as_ref().unchecked_ref(),
+            web_sys::AddEventListenerOptions::new().once(true),
+        )
+        .map_err(js_to_js_error)?;
 
         Ok(Self {
             ws,
@@ -299,6 +311,25 @@ impl Stream for WebSocket {
 impl PinnedDrop for WebSocket {
     fn drop(self: Pin<&mut Self>) {
         self.ws.close().unwrap();
+
+        for (ty, cb) in [
+            ("open", self.closures.0.as_ref()),
+            ("message", &self.closures.1.as_ref()),
+            ("error", &self.closures.2.as_ref()),
+        ] {
+            let _ = self
+                .ws
+                .remove_event_listener_with_callback(ty, cb.unchecked_ref());
+        }
+
+        if let Ok(close_event) = web_sys::CloseEvent::new_with_event_init_dict(
+            "close",
+            web_sys::CloseEventInit::new()
+                .code(1000)
+                .reason("client dropped"),
+        ) {
+            let _ = self.ws.dispatch_event(&close_event);
+        }
     }
 }
 


### PR DESCRIPTION
I notice the following error:

![image](https://user-images.githubusercontent.com/656711/199669373-2c9738e8-491c-4a59-a44e-ea94b6365bac.png)

And it's 100% reproduced when `wasm-pack test --chrome`.

It's a racing condition: 

* call `Websocket::close`, which **consumes the ownership**.
* `Websocket::drop` is executed emmediately
  * call `self.ws.close()` the second time (and it doesn't matter).
  * the closures (event listeners) are dropped (and it matters).
* `self.ws.onclose` is called with destroyed `close` callback.

Solution:
* bind`open/close` event listeners once (which I think okay, tell me if not)
* unbind the `open/message/error` eventlisteners when dropping
* trigger `close` event to notify the user (and unbind).