### PR TITLE
Prevent Websocket send from hanging if connection fails.

### DIFF
--- a/crates/net/src/websocket/futures.rs
+++ b/crates/net/src/websocket/futures.rs
@@ -156,7 +156,11 @@ impl WebSocket {
 
         let error_callback: Closure<dyn FnMut(web_sys::Event)> = {
             let sender = sender.clone();
+            let waker = Rc::clone(&waker);
             Closure::wrap(Box::new(move |_e: web_sys::Event| {
+                if let Some(waker) = waker.borrow_mut().take() {
+                    waker.wake();
+                }
                 let _ = sender.unbounded_send(StreamMessage::ErrorEvent);
             }) as Box<dyn FnMut(web_sys::Event)>)
         };


### PR DESCRIPTION
I have just found out that the following code hangs if no server is running on port 9321:

```rust
let ws = WebSocket::open("ws://localhost:9321").unwrap();
let (mut sender, mut receiver) = ws.split();
let _ = sender.send(Message::Text("test".into())).await;
```

this is because if the server is not running the `open_callback` is not called and the `waker` is not waked causing `poll_ready` to always return `Pending`. 

This PR adds a `wake()` call on the `error_callback` so that `poll_ready` will move to `Ready` also if an error occurs.  
