### PR TITLE
fix: `clearTimeout` illegal invocation with bundler (#187)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,43 @@ jobs:
             wasm-pack test --headless --firefox --chrome crates/$x --no-default-features
           done
 
+  node_tests:
+    name: Node Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+          profile: minimal
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-node-tests-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-node-tests-
+            cargo-${{ runner.os }}-
+
+      - name: Run tests
+        run: |
+          for x in $(ls crates); do
+            # gloo-net is tested separately
+            if [[ "$x" == "net" ]]; then
+              continue
+            fi
+            wasm-pack test --node crates/$x --all-features
+            wasm-pack test --node crates/$x --no-default-features
+          done
+
   test-worker:
     name: Test gloo-worker
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ yourself.
   - [Building](#building)
   - [Testing](#testing)
     - [Wasm Headless Browser Tests](#wasm-headless-browser-tests)
+    - [Wasm Node Tests](#wasm-node-tests)
     - [Non-Wasm Tests](#non-wasm-tests)
   - [Formatting](#formatting)
   - [Updating `README.md`s](#updating-readmemds)
@@ -79,6 +80,14 @@ To run headless browser tests for a particular crate:
 
 ```shell
 wasm-pack test crates/my-particular-crate --headless --firefox # or --safari or --chrome
+```
+
+#### Wasm Node Tests
+
+To run tests in Node.js:
+
+```shell
+wasm-pack test crates/my-particular-crate --node
 ```
 
 #### Non-Wasm Tests

--- a/crates/timers/tests/node.rs
+++ b/crates/timers/tests/node.rs
@@ -14,8 +14,6 @@ use std::rc::Rc;
 use std::time::Duration;
 use wasm_bindgen_test::*;
 
-wasm_bindgen_test_configure!(run_in_browser);
-
 #[wasm_bindgen_test]
 async fn timeout() {
     let (sender, receiver) = oneshot::channel();


### PR DESCRIPTION
~~It's a regression from #96 introduced by #185, and I have no idea why calling `clearTimeout` is failed in browser, but my patch definitely resolves the error.~~

It's a side effect introduced by bundler, and we workaround it. more details in https://github.com/rustwasm/gloo/pull/283#issuecomment-1396668213