### PR TITLE
(history): Drop states borrow before callback invocation

### DIFF
--- a/crates/history/src/browser.rs
+++ b/crates/history/src/browser.rs
@@ -85,6 +85,7 @@ impl History for BrowserHistory {
             .push_state_with_url(&history_state, "", Some(&url))
             .expect_throw("failed to push state.");
 
+        drop(states);
         self.notify_callbacks();
     }
 
@@ -98,10 +99,12 @@ impl History for BrowserHistory {
 
         let mut states = self.states.borrow_mut();
         states.insert(id, Rc::new(state) as Rc<dyn Any>);
+
         self.inner
             .replace_state_with_url(&history_state, "", Some(&url))
             .expect_throw("failed to replace state.");
 
+        drop(states);
         self.notify_callbacks();
     }
 
@@ -170,6 +173,7 @@ impl History for BrowserHistory {
             .push_state_with_url(&history_state, "", Some(&url))
             .expect_throw("failed to push history.");
 
+        drop(states);
         self.notify_callbacks();
         Ok(())
     }
@@ -199,6 +203,7 @@ impl History for BrowserHistory {
             .replace_state_with_url(&history_state, "", Some(&url))
             .expect_throw("failed to replace history.");
 
+        drop(states);
         self.notify_callbacks();
         Ok(())
     }

--- a/crates/history/tests/browser_history.rs
+++ b/crates/history/tests/browser_history.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 
 use gloo_history::{BrowserHistory, History};
@@ -42,4 +44,15 @@ async fn history_works() {
         let history = history.clone();
         delayed_assert_eq(move || history.location().path().to_owned(), || "/path-b").await;
     }
+
+    let _listener = history.listen({
+        let history = history.clone();
+        move || {
+            let location = history.location();
+            let state: Option<Rc<String>> = location.state();
+            assert_eq!(state, Some(Rc::new(location.path().to_owned())));
+        }
+    });
+
+    history.push_with_state("/fish", String::from("/fish"));
 }


### PR DESCRIPTION
To prevent situations of 'already mutably borrowed: BorrowError' when invoking callbacks from BrowserHistory where state is in use, drop the borrow before invoking the callbacks.

This fixes #284 