### PR TITLE
Replace unmaintained actions-rs/cargo actions in CI workflows

### DIFF
--- a/.github/workflows/lint-fmt.yml
+++ b/.github/workflows/lint-fmt.yml
@@ -29,10 +29,7 @@ jobs:
             cargo-${{ runner.os }}-
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -58,10 +55,7 @@ jobs:
             cargo-${{ runner.os }}-
 
       - name: Run clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features
+        run: cargo clippy --all-targets --all-features
 
       - name: Run clippy for gloo-net
         working-directory: crates/net

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,10 +29,7 @@ jobs:
             cargo-${{ runner.os }}-
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --exclude gloo-net
+        run: cargo test --workspace --exclude gloo-net
 
   browser_tests:
     name: Browser Tests
@@ -215,7 +212,4 @@ jobs:
           HTTPBIN_URL: "http://localhost:8080"
           WS_ECHO_SERVER_URL: "ws://localhost:8081"
           SSE_ECHO_SERVER_URL: "http://localhost:8081/.sse"
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -p gloo-net --all-features
+        run: cargo test -p gloo-net --all-features


### PR DESCRIPTION
Basically all of the `actions-rs/*` actions are unmaintained. See <https://github.com/actions-rs/toolchain/issues/216> for more information. Due to their age they generate several warnings in CI runs, for example in https://github.com/rustwasm/gloo/actions/runs/4136537026:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions-rs/toolchain@v1, actions-rs/cargo@v1. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

To get rid of some of those warnings the occurrences of `actions-rs/cargo` are replaced by direct invocations of `cargo`.