### PR TITLE
Seanaye/feat/add misc methods

### DIFF
--- a/crates/net/src/http/mod.rs
+++ b/crates/net/src/http/mod.rs
@@ -24,4 +24,4 @@ pub use http::Method;
 pub use query::QueryParams;
 
 pub use request::Request;
-pub use response::{IntoRawResponse, Response};
+pub use response::{IntoRawResponse, Response, ResponseBuilder};

--- a/crates/net/src/http/request.rs
+++ b/crates/net/src/http/request.rs
@@ -343,6 +343,11 @@ impl Request {
             .map_err(|e| panic!("fetch returned {:?}, not `Response` - this is a bug", e))
             .map(Response::from)
     }
+    /// attempts to clone the request via the Request.clone api
+    pub fn try_clone(&self) -> Result<Self, Error> {
+        let clone = self.0.clone().map_err(js_to_error)?;
+        Ok(Self(clone))
+    }
 }
 
 impl From<web_sys::Request> for Request {

--- a/crates/net/src/http/response.rs
+++ b/crates/net/src/http/response.rs
@@ -177,6 +177,23 @@ impl ResponseBuilder {
         self
     }
 
+    /// Get a reference to the contained headers
+    pub fn get_headers(&self) -> &Headers {
+        &self.headers
+    }
+
+    /// Get the contained status code if it exists
+    pub fn get_status(&self) -> Option<f64> {
+        js_sys::Reflect::get(&self.options, &JsValue::from_str("status")).ok()?.as_f64()
+    }
+
+    /// Get the contained status text if it exists
+    pub fn get_status_text(&self) -> Option<String> {
+        js_sys::Reflect::get(&self.options, &JsValue::from_str("statusText"))
+            .ok()?
+            .as_string()
+    }
+
     /// Set the status code
     pub fn status(mut self, status: u16) -> Self {
         self.options.status(status);
@@ -278,4 +295,16 @@ impl fmt::Debug for ResponseBuilder {
             .field("headers", &self.headers)
             .finish_non_exhaustive()
     }
+}
+
+impl Clone for ResponseBuilder {
+    fn clone(&self) -> Self {
+        let headers = Headers::new();
+        for (name, value) in self.headers.entries() {
+            headers.append(name.as_str(), value.as_str())
+        }
+        let options = self.options.clone();
+        Self { headers, options }
+    }
+
 }


### PR DESCRIPTION
Adds a number of utility methods that I have needed while working on a server integration

* Getting properties from the `ResponseBuilder`
* Access to the Response.clone javascript method [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Response/clone)
* Clone trait for `ResponseBuilder`