### PR TITLE
Add WebSocket::inner method

### DIFF
--- a/crates/net/src/websocket/futures.rs
+++ b/crates/net/src/websocket/futures.rs
@@ -199,6 +199,11 @@ impl WebSocket {
         })
     }
 
+    /// Provides a reference to the JS `WebSocket` instance wrapped by this struct.
+    pub fn inner(&self) -> &web_sys::WebSocket {
+        &self.ws
+    }
+
     /// Closes the websocket.
     ///
     /// See the [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close#parameters)


### PR DESCRIPTION
This is useful to call e.g. [`buffered_amount`](https://docs.rs/web-sys/latest/web_sys/struct.WebSocket.html#method.buffered_amount).