### PR TITLE
Add an example of processing transferrable types with worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,5 @@ members = [
 
     "examples/markdown",
     "examples/clock",
+    "examples/file-hash",
 ]

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -28,9 +28,10 @@ use web_sys::{AddEventListenerOptions, Event, EventTarget};
 /// EventListenerPhase::Bubble
 /// # ;
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum EventListenerPhase {
     #[allow(missing_docs)]
+    #[default]
     Bubble,
 
     #[allow(missing_docs)]
@@ -44,13 +45,6 @@ impl EventListenerPhase {
             EventListenerPhase::Bubble => false,
             EventListenerPhase::Capture => true,
         }
-    }
-}
-
-impl Default for EventListenerPhase {
-    #[inline]
-    fn default() -> Self {
-        EventListenerPhase::Bubble
     }
 }
 

--- a/examples/file-hash/Cargo.toml
+++ b/examples/file-hash/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# We use gloo-worker to avoid dependency conflicts as Yew also uses gloo
+# We use the gloo-worker directly to avoid dependency conflicts as Yew also uses gloo.
 gloo-worker = { path = "../../crates/worker" }
 serde = "1.0.163"
 web-sys = { version = "0.3.63", features = ["File", "Blob", "ReadableStream"] }

--- a/examples/file-hash/Cargo.toml
+++ b/examples/file-hash/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "example-file-hash"
+version = "0.1.0"
+edition = "2021"
+authors = ["Rust and WebAssembly Working Group"]
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+# We use gloo-worker to avoid dependency conflicts as Yew also uses gloo
+gloo-worker = { path = "../../crates/worker" }
+serde = "1.0.163"
+web-sys = { version = "0.3.63", features = ["File", "Blob", "ReadableStream"] }
+wasm-bindgen-futures = { version = "0.4" }
+wasm-streams = "0.3.0"
+wasm-bindgen = "0.2.86"
+futures = "0.3.28"
+sha2 = "0.10.6"
+console_error_panic_hook = "0.1.7"
+yew = { version = "0.20.0", features = ["csr"] }
+serde-wasm-bindgen = "0.5.0"
+js-sys = "0.3.63"
+hex = "0.4.3"

--- a/examples/file-hash/README.md
+++ b/examples/file-hash/README.md
@@ -1,0 +1,5 @@
+# File Hash example
+
+This is a simple example showcasing the Gloo Workers custom codec and how to send transferrable types to workers.
+
+You can run this example with `trunk serve --open`

--- a/examples/file-hash/index.html
+++ b/examples/file-hash/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>File Hasher</title>
+
+        <link data-trunk rel="rust" data-type="worker" data-wasm-opt="z" data-bin="example_file_hash_worker" />
+        <link data-trunk rel="rust" data-wasm-opt="z" data-bin="example_file_hash_app" />
+    </head>
+</html>

--- a/examples/file-hash/src/bin/example_file_hash_app.rs
+++ b/examples/file-hash/src/bin/example_file_hash_app.rs
@@ -1,0 +1,67 @@
+use std::ops::Deref;
+
+use example_file_hash::codec::TransferrableCodec;
+use example_file_hash::{HashInput, HashWorker};
+use gloo_worker::Spawnable;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+#[function_component]
+fn App() -> Html {
+    let result = use_state(|| None);
+    let calculating = use_state(|| false);
+
+    let worker = {
+        let calculating = calculating.clone();
+        let result = result.clone();
+
+        use_memo(
+            move |_| {
+                HashWorker::spawner()
+                    .callback(move |o| {
+                        calculating.set(false);
+                        result.set(Some(o.hash));
+                    })
+                    .encoding::<TransferrableCodec>()
+                    .spawn("/example_file_hash_worker.js")
+            },
+            (),
+        )
+    };
+
+    let on_choose_file = {
+        let calculating = calculating.clone();
+        let result = result.clone();
+        use_callback(
+            move |e: Event, _i| {
+                let el: HtmlInputElement = e.target_unchecked_into();
+                if let Some(f) = el.files().and_then(|m| m.item(0)) {
+                    calculating.set(true);
+                    result.set(None);
+                    let input = HashInput { file: Some(f) };
+                    TransferrableCodec::pre_encode_input(&input);
+                    worker.send(input);
+                }
+            },
+            (),
+        )
+    };
+
+    html! {
+        <div>
+            <h1>{"To calculate file hash, please select a file below:"}</h1>
+            <p><input type="file" disabled={*calculating} onchange={on_choose_file} /></p>
+            if let Some(m) = result.deref().clone() {
+                <p><h4>{"SHA256: "}{&m}</h4></p>
+            }
+            if *calculating {
+                <p><h4>{"Calculating..."}</h4></p>
+            }
+        </div>
+    }
+}
+
+fn main() {
+    console_error_panic_hook::set_once();
+    yew::Renderer::<App>::new().render();
+}

--- a/examples/file-hash/src/bin/example_file_hash_worker.rs
+++ b/examples/file-hash/src/bin/example_file_hash_worker.rs
@@ -1,0 +1,11 @@
+use example_file_hash::codec::TransferrableCodec;
+use example_file_hash::HashWorker;
+
+use gloo_worker::Registrable;
+
+fn main() {
+    console_error_panic_hook::set_once();
+    HashWorker::registrar()
+        .encoding::<TransferrableCodec>()
+        .register();
+}

--- a/examples/file-hash/src/codec.rs
+++ b/examples/file-hash/src/codec.rs
@@ -1,0 +1,79 @@
+use std::cell::RefCell;
+
+use gloo_worker::Codec;
+use js_sys::{Array, JsString, Reflect};
+use wasm_bindgen::JsCast;
+use web_sys::File;
+
+use crate::HashInput;
+
+thread_local! {
+    static FILE_STORE: RefCell<Option<File>> = RefCell::new(None);
+}
+
+pub struct TransferrableCodec {}
+
+impl TransferrableCodec {
+    pub fn pre_encode_input(input: &HashInput) {
+        let file = input.file.clone();
+        FILE_STORE.with(|m| m.replace(file));
+    }
+
+    pub fn post_decode_input(input: &mut HashInput) {
+        let f = FILE_STORE.with(|m| m.take());
+        input.file = f;
+    }
+}
+
+impl Codec for TransferrableCodec {
+    fn encode<I>(input: I) -> wasm_bindgen::JsValue
+    where
+        I: serde::Serialize,
+    {
+        let i = serde_wasm_bindgen::to_value(&input).expect("failed to encode");
+        // This relys on some internal implementation details about gloo worker message types.
+        // This should be considered as a last resort approach after all other possibilities are exhausted.
+        if i.is_object() {
+            if let Ok(m) = Reflect::get(&i, &JsString::from("ProcessInput")) {
+                if let Ok(m) = m.dyn_into::<Array>() {
+                    // HandlerID is ignored here. If it is possible to have multiple handles,
+                    // Please consider using a hash map keyed by handler id for file store.
+                    let i = m.get(1);
+
+                    if i.is_object() {
+                        if let Some(f) = FILE_STORE.with(|m| m.take()) {
+                            Reflect::set(&i, &JsString::from("file"), &f)
+                                .expect("failed to store file.");
+                        }
+                    }
+                }
+            }
+        }
+
+        i
+    }
+
+    fn decode<O>(input: wasm_bindgen::JsValue) -> O
+    where
+        O: for<'de> serde::Deserialize<'de>,
+    {
+        if input.is_object() {
+            if let Ok(m) = Reflect::get(&input, &JsString::from("ProcessInput")) {
+                if let Ok(m) = m.dyn_into::<Array>() {
+                    let i = m.get(1);
+
+                    if i.is_object() {
+                        let f: Option<web_sys::File> = Reflect::get(&i, &JsString::from("file"))
+                            .expect("failed to read file.")
+                            .dyn_into()
+                            .ok();
+
+                        FILE_STORE.with(move |m| m.replace(f));
+                    }
+                }
+            }
+        }
+
+        serde_wasm_bindgen::from_value(input).expect("failed to decode")
+    }
+}

--- a/examples/file-hash/src/codec.rs
+++ b/examples/file-hash/src/codec.rs
@@ -33,6 +33,13 @@ impl Codec for TransferrableCodec {
         let i = serde_wasm_bindgen::to_value(&input).expect("failed to encode");
         // This relys on some internal implementation details about gloo worker message types.
         // This should be considered as a last resort approach after all other possibilities are exhausted.
+        //
+        // Using this approach could potentially create unsound code.
+        // This could cause data being sent to wrong worker or with wrong handler id if mitigations are not
+        // in place.
+        // You should only use this if you know how to make it sound.
+        // This example mitigates it by only allowing 1 file to be processed at 1 time
+        // and only 1 worker instance across the entire tab.
         if i.is_object() {
             if let Ok(m) = Reflect::get(&i, &JsString::from("ProcessInput")) {
                 if let Ok(m) = m.dyn_into::<Array>() {

--- a/examples/file-hash/src/lib.rs
+++ b/examples/file-hash/src/lib.rs
@@ -43,7 +43,7 @@ impl Worker for HashWorker {
             let scope = scope.clone();
 
             spawn_local(async move {
-                // This is a demonstration of codec and passing transferrable types to worker.
+                // This is a demonstration of codec and how to pass transferrable types to worker.
                 //
                 // If you are trying to calculate hashes in browsers for your application,
                 // please consider using subtle crypto.

--- a/examples/file-hash/src/lib.rs
+++ b/examples/file-hash/src/lib.rs
@@ -1,0 +1,70 @@
+use codec::TransferrableCodec;
+use futures::TryStreamExt;
+use gloo_worker::{HandlerId, Worker, WorkerScope};
+use js_sys::Uint8Array;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
+use wasm_streams::ReadableStream;
+
+pub mod codec;
+
+#[derive(Serialize, Deserialize)]
+pub struct HashInput {
+    #[serde(skip)]
+    pub file: Option<web_sys::File>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct HashOutput {
+    pub hash: String,
+}
+
+pub struct HashWorker {}
+
+impl Worker for HashWorker {
+    type Input = HashInput;
+    type Output = HashOutput;
+    type Message = ();
+
+    fn create(_scope: &WorkerScope<Self>) -> Self {
+        Self {}
+    }
+
+    fn connected(&mut self, _scope: &WorkerScope<Self>, _id: HandlerId) {}
+
+    fn update(&mut self, _scope: &WorkerScope<Self>, _msg: Self::Message) {}
+
+    fn received(&mut self, scope: &WorkerScope<Self>, mut msg: Self::Input, id: HandlerId) {
+        TransferrableCodec::post_decode_input(&mut msg);
+
+        if let Some(m) = msg.file {
+            let scope = scope.clone();
+
+            spawn_local(async move {
+                // This is more of a demonstration of processing transferrable types
+                // than how to calculate hashes,
+                // if you are trying to calculate hashes in browsers for your application,
+                // please consider subtle crypto.
+                // This example does not use subtle crypto
+                // because calculating hashes with subtle crypto doesn't need to be sent to a worker.
+                let mut hasher = Sha256::new();
+
+                // We assume that this file is big and cannot be loaded into the memory in one chunk.
+                // So we process this in chunks.
+                let mut s = ReadableStream::from_raw(m.stream().unchecked_into()).into_stream();
+
+                while let Some(chunk) = s.try_next().await.unwrap() {
+                    hasher.update(chunk.unchecked_into::<Uint8Array>().to_vec());
+                }
+
+                let hash = hasher.finalize();
+
+                let hash_hex = hex::encode(hash);
+
+                scope.respond(id, HashOutput { hash: hash_hex });
+            });
+        }
+    }
+}

--- a/examples/file-hash/src/lib.rs
+++ b/examples/file-hash/src/lib.rs
@@ -43,16 +43,17 @@ impl Worker for HashWorker {
             let scope = scope.clone();
 
             spawn_local(async move {
-                // This is more of a demonstration of processing transferrable types
-                // than how to calculate hashes,
-                // if you are trying to calculate hashes in browsers for your application,
-                // please consider subtle crypto.
+                // This is a demonstration of codec and passing transferrable types to worker.
+                //
+                // If you are trying to calculate hashes in browsers for your application,
+                // please consider using subtle crypto.
+                //
                 // This example does not use subtle crypto
                 // because calculating hashes with subtle crypto doesn't need to be sent to a worker.
                 let mut hasher = Sha256::new();
 
                 // We assume that this file is big and cannot be loaded into the memory in one chunk.
-                // So we process this in chunks.
+                // So we process this as a stream.
                 let mut s = ReadableStream::from_raw(m.stream().unchecked_into()).into_stream();
 
                 while let Some(chunk) = s.try_next().await.unwrap() {


### PR DESCRIPTION
See: #275 

This pull request adds an example to demonstrate how to use custom codecs for transferrable types.