### PR TITLE
history: Fix required feature set of serde dependency

### DIFF
--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["api-bindings", "history", "wasm"]
 wasm-bindgen = "0.2"
 gloo-utils = { version = "0.1.7", path = "../utils" }
 gloo-events = { version = "0.1.0", path = "../events" }
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.5.0"
 serde_urlencoded = { version = "0.7", optional = true }
 thiserror = { version = "1.0", optional = true }
@@ -30,7 +30,6 @@ features = [
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-serde = { version = "1", features = ["derive"] }
 gloo-timers = { version = "0.2.6", features = ["futures"], path = "../timers" }
 
 [features]

--- a/crates/history/src/any.rs
+++ b/crates/history/src/any.rs
@@ -105,7 +105,7 @@ impl History for AnyHistory {
         }
     }
 
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn push_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -123,7 +123,7 @@ impl History for AnyHistory {
         }
     }
 
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn replace_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,

--- a/crates/history/src/browser.rs
+++ b/crates/history/src/browser.rs
@@ -148,7 +148,7 @@ impl History for BrowserHistory {
         Ok(())
     }
 
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn push_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -178,7 +178,7 @@ impl History for BrowserHistory {
         Ok(())
     }
 
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn replace_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,

--- a/crates/history/src/hash.rs
+++ b/crates/history/src/hash.rs
@@ -134,7 +134,7 @@ impl History for HashHistory {
         Ok(())
     }
 
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn push_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -160,7 +160,7 @@ impl History for HashHistory {
         Ok(())
     }
 
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn replace_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -71,7 +71,7 @@ pub trait History: Clone + PartialEq {
         Q: Serialize;
 
     /// Same as `.push_with_state()` but affix the queries to the end of the route.
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn push_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -83,7 +83,7 @@ pub trait History: Clone + PartialEq {
         T: 'static;
 
     /// Same as `.replace_with_state()` but affix the queries to the end of the route.
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn replace_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,

--- a/crates/history/src/memory.rs
+++ b/crates/history/src/memory.rs
@@ -266,7 +266,7 @@ impl History for MemoryHistory {
         Ok(())
     }
 
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn push_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,
@@ -299,7 +299,7 @@ impl History for MemoryHistory {
         Ok(())
     }
 
-    #[cfg(all(feature = "query"))]
+    #[cfg(feature = "query")]
     fn replace_with_query_and_state<'a, Q, T>(
         &self,
         route: impl Into<Cow<'a, str>>,

--- a/crates/history/tests/browser_history_feat_serialize.rs
+++ b/crates/history/tests/browser_history_feat_serialize.rs
@@ -2,10 +2,10 @@ use wasm_bindgen_test::wasm_bindgen_test_configure;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-#[cfg(all(feature = "query"))]
+#[cfg(feature = "query")]
 mod utils;
 
-#[cfg(all(feature = "query"))]
+#[cfg(feature = "query")]
 mod feat_serialize {
     use super::*;
 

--- a/crates/history/tests/hash_history_feat_serialize.rs
+++ b/crates/history/tests/hash_history_feat_serialize.rs
@@ -2,10 +2,10 @@ use wasm_bindgen_test::wasm_bindgen_test_configure;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-#[cfg(all(feature = "query"))]
+#[cfg(feature = "query")]
 mod utils;
 
-#[cfg(all(feature = "query"))]
+#[cfg(feature = "query")]
 mod feat_serialize {
     use super::*;
 

--- a/crates/history/tests/memory_history_feat_serialize.rs
+++ b/crates/history/tests/memory_history_feat_serialize.rs
@@ -2,7 +2,7 @@ use wasm_bindgen_test::wasm_bindgen_test_configure;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-#[cfg(all(feature = "query"))]
+#[cfg(feature = "query")]
 mod feat_serialize {
     use wasm_bindgen_test::wasm_bindgen_test as test;
 


### PR DESCRIPTION
The state module uses Serialize and Deserialize as derive macros, but those are only available with the derive feature.

Also simplify some cfg expressions in the same crate.