### PR TITLE
Make RequestBuilder and ResponseBuilder public for docs

### DIFF
--- a/crates/net/src/http/mod.rs
+++ b/crates/net/src/http/mod.rs
@@ -23,5 +23,5 @@ pub use headers::Headers;
 pub use http::Method;
 pub use query::QueryParams;
 
-pub use request::Request;
-pub use response::{IntoRawResponse, Response};
+pub use request::{Request, RequestBuilder};
+pub use response::{IntoRawResponse, Response, ResponseBuilder};


### PR DESCRIPTION
Docs are not currently generated for `RequestBuilder` or `ResponseBuilder`:

![image](https://github.com/rustwasm/gloo/assets/179065/be452b6b-eb8f-4d4e-acdd-b6ace787a57d)

These types need to be made public here to fix this

fixes #353