### PR TITLE
Migrate to Edition 2021

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,13 +7,17 @@ on:
 
 jobs:
   native_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-version: [1.64, stable, nightly]
     name: Native Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust-version }}
 
       - uses: actions/cache@v3
         with:
@@ -30,13 +34,17 @@ jobs:
         run: cargo test --workspace --exclude gloo-net
 
   browser_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-version: [1.64, stable, nightly]
     name: Browser Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust-version }}
           target: wasm32-unknown-unknown
 
       - name: Install wasm-pack
@@ -73,13 +81,17 @@ jobs:
           done
 
   node_tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-version: [1.64, stable, nightly]
     name: Node Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust-version }}
           target: wasm32-unknown-unknown
 
       - name: Install wasm-pack
@@ -115,11 +127,12 @@ jobs:
       matrix:
         # example: [ markdown, prime ]
         example: [ markdown ]
+        rust-version: [1.64, stable, nightly]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust-version }}
           target: wasm32-unknown-unknown
 
       - name: Install wasm-pack
@@ -156,6 +169,10 @@ jobs:
 
 
   test-net:
+    strategy:
+      fail-fast: false
+      matrix:
+        rust-version: [1.64, stable, nightly]
     name: Test gloo-net
     runs-on: ubuntu-latest
     services:
@@ -200,7 +217,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust-version }}
           target: wasm32-unknown-unknown
 
       - name: Run native tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## `console`
 
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
+
 ### Version "0.2.3"
 
 - Release new gloo versions
@@ -21,18 +25,23 @@
 
 ### Version "0.1.0"
 
-- Add an `dbg!` equivalent to `gloo-console`  (#158)
+- Add an `dbg!` equivalent to `gloo-console` (#158)
 - Fix dir, dirxml macros in gloo-console (#154)
 - Finishing touches
 
-
 ## `dialogs`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version "0.1.0"
 
-
-
 ## `events`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version "0.1.1"
 
@@ -67,8 +76,11 @@
 - Renaming A parameter to S
 - Fixing all the issues with gloo-events
 
-
 ## `file`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version "0.2.2"
 
@@ -90,12 +102,15 @@
 - Adding README for gloo-file
 - Fixing Cargo.toml for gloo-file
 
-
 ## `history`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version 0.1.4
 
-- Use thread_local!'s lazy initialization instead of RefCell<Option<_>> (#358)
+- Use `thread_local!`'s lazy initialization instead of `RefCell<Option<_>>` (#358)
 - Fix required feature set of serde dependency (#357)
 
 ### Version "0.1.3"
@@ -124,8 +139,11 @@
 - Memory-based History (#178)
 - Hash-based History type & Unified Location. (#177)
 
-
 ## `net`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version "0.3.1"
 
@@ -186,14 +204,19 @@
 - add `json()` impl to `Request` (#204)
 - Improve the Fetch API (#188)
 
-
 ## `render`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version "0.1.0"
 
-
-
 ## `storage`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version "0.2.1"
 
@@ -208,8 +231,11 @@
 
 - Utility crate for common `web_sys`/`js_sys` features (#155)
 
-
 ## `timers`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version "0.2.5"
 
@@ -275,8 +301,11 @@
 - Split up callback and future/stream APIs.
 - timers: Fix author line in Cargo.toml
 
-
 ## `utils`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version "0.1.6"
 
@@ -312,8 +341,11 @@
 
 - utils: Add body() and document_element() getters (#161)
 
-
 ## `worker`
+
+### Next Version
+
+- Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
 
 ### Version 0.3.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Rust and WebAssembly Working Group"]
 description = "A modular toolkit for Rust and WebAssembly"
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 name = "gloo"
 readme = "README.md"
@@ -10,6 +10,7 @@ repository = "https://github.com/rustwasm/gloo"
 homepage = "https://gloo-rs.web.app/"
 documentation = "https://docs.rs/gloo/"
 categories = ["api-bindings", "wasm"]
+rust-version = "1.56"
 
 [dependencies]
 gloo-timers = { version = "0.2", path = "crates/timers", optional = true }
@@ -44,7 +45,7 @@ futures = [
     "worker",
     "gloo-timers/futures",
     "gloo-file/futures",
-    "gloo-worker/futures"
+    "gloo-worker/futures",
 ]
 timers = ["gloo-timers"]
 events = ["gloo-events"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rustwasm/gloo"
 homepage = "https://gloo-rs.web.app/"
 documentation = "https://docs.rs/gloo/"
 categories = ["api-bindings", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [dependencies]
 gloo-timers = { version = "0.2", path = "crates/timers", optional = true }

--- a/crates/console/Cargo.toml
+++ b/crates/console/Cargo.toml
@@ -3,13 +3,14 @@ name = "gloo-console"
 description = "Convenience crate for working with browser's console"
 version = "0.2.3"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/console"
 homepage = "https://github.com/rustwasm/gloo"
 documentation = "https://docs.rs/gloo-console/"
 categories = ["api-bindings", "development-tools::profiling", "wasm"]
+rust-version = "1.56"
 
 [dependencies]
 wasm-bindgen = "0.2"
@@ -18,10 +19,7 @@ serde = { version = "1", features = ["derive"] }
 gloo-utils = { version = "0.1", path = "../utils", features = ["serde"] }
 [dependencies.web-sys]
 version = "0.3"
-features = [
-    "console",
-    "Document"
-]
+features = ["console", "Document"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.4"

--- a/crates/console/Cargo.toml
+++ b/crates/console/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rustwasm/gloo/tree/master/crates/console"
 homepage = "https://github.com/rustwasm/gloo"
 documentation = "https://docs.rs/gloo-console/"
 categories = ["api-bindings", "development-tools::profiling", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/crates/dialogs/Cargo.toml
+++ b/crates/dialogs/Cargo.toml
@@ -3,18 +3,17 @@ name = "gloo-dialogs"
 description = "Convenience crate for working with dialogs in browser"
 version = "0.1.1"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/dialogs"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
+rust-version = "1.56"
 
 [dependencies]
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]
 version = "0.3"
-features = [
-    "Window"
-]
+features = ["Window"]

--- a/crates/dialogs/Cargo.toml
+++ b/crates/dialogs/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/dialogs"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/events"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "web-programming", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -3,23 +3,20 @@ name = "gloo-events"
 description = "Convenience crate for working with DOM event listeners"
 version = "0.1.2"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/events"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "web-programming", "wasm"]
+rust-version = "1.56"
 
 [dependencies]
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]
 version = "0.3.31"
-features = [
-    "Event",
-    "EventTarget",
-    "AddEventListenerOptions",
-]
+features = ["Event", "EventTarget", "AddEventListenerOptions"]
 
 [dev-dependencies]
 js-sys = "0.3.31"

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -28,8 +28,9 @@ use web_sys::{AddEventListenerOptions, Event, EventTarget};
 /// EventListenerPhase::Bubble
 /// # ;
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy)]
 pub enum EventListenerPhase {
+    #[default]
     #[allow(missing_docs)]
     Bubble,
 
@@ -44,13 +45,6 @@ impl EventListenerPhase {
             EventListenerPhase::Bubble => false,
             EventListenerPhase::Capture => true,
         }
-    }
-}
-
-impl Default for EventListenerPhase {
-    #[inline]
-    fn default() -> Self {
-        EventListenerPhase::Bubble
     }
 }
 

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -3,12 +3,13 @@ name = "gloo-file"
 description = "Convenience crate for working with JavaScript files and blobs"
 version = "0.2.3"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/file"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 features = ["futures"]

--- a/crates/file/Cargo.toml
+++ b/crates/file/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/file"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 features = ["futures"]

--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -3,12 +3,13 @@ name = "gloo-history"
 version = "0.1.5"
 description = "Universal Session History"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/history"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "history", "wasm"]
+rust-version = "1.56"
 
 [dependencies]
 wasm-bindgen = "0.2"
@@ -21,12 +22,7 @@ thiserror = { version = "1.0", optional = true }
 
 [dependencies.web-sys]
 version = "0.3"
-features = [
-    "History",
-    "Window",
-    "Location",
-    "Url",
-]
+features = ["History", "Window", "Location", "Url"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/history"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "history", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -12,7 +12,7 @@ description = "HTTP requests library for WASM Apps"
 readme = "README.md"
 keywords = ["requests", "http", "wasm", "websockets"]
 categories = ["wasm", "web-programming::http-client", "api-bindings"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
 name = "gloo-net"
 version = "0.3.1"
-authors = ["Rust and WebAssembly Working Group", "Muhammad Hamza <muhammadhamza1311@gmail.com>"]
-edition = "2018"
+authors = [
+    "Rust and WebAssembly Working Group",
+    "Muhammad Hamza <muhammadhamza1311@gmail.com>",
+]
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustwasm/gloo"
 description = "HTTP requests library for WASM Apps"
 readme = "README.md"
 keywords = ["requests", "http", "wasm", "websockets"]
 categories = ["wasm", "web-programming::http-client", "api-bindings"]
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/storage"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "storage", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/crates/render/Cargo.toml
+++ b/crates/render/Cargo.toml
@@ -3,18 +3,17 @@ name = "gloo-render"
 description = "Convenience crate for working with browser's requestAnimationFrame"
 version = "0.1.1"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/storage"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "storage", "wasm"]
+rust-version = "1.56"
 
 [dependencies]
 wasm-bindgen = "0.2"
 
 [dependencies.web-sys]
 version = "0.3"
-features = [
-    "Window"
-]
+features = ["Window"]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/storage"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "storage", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -3,12 +3,13 @@ name = "gloo-storage"
 description = "Convenience crate for working with local and session storage in browser"
 version = "0.2.2"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/storage"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "storage", "wasm"]
+rust-version = "1.56"
 
 [dependencies]
 wasm-bindgen = "0.2"
@@ -19,10 +20,7 @@ js-sys = "0.3"
 gloo-utils = { version = "0.1", path = "../utils" }
 [dependencies.web-sys]
 version = "0.3"
-features = [
-    "Storage",
-    "Window",
-]
+features = ["Storage", "Window"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/timers/Cargo.toml
+++ b/crates/timers/Cargo.toml
@@ -3,12 +3,13 @@ name = "gloo-timers"
 description = "Convenience crate for working with JavaScript timers"
 version = "0.2.6"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/timers"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 features = ["futures"]

--- a/crates/timers/Cargo.toml
+++ b/crates/timers/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/timers"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "asynchronous", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 features = ["futures"]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gloo-utils"
 version = "0.1.7"
-edition = "2018"
+edition = "2021"
 description = "Convenience crate for common `web_sys` features"
 authors = ["Rust and WebAssembly Working Group"]
 license = "MIT OR Apache-2.0"
@@ -9,13 +9,14 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/utils"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "wasm"]
+rust-version = "1.56"
 
 
 [dependencies]
 wasm-bindgen = "0.2"
 js-sys = "0.3"
-serde =  { version = "1.0", optional = true }
-serde_json = {version = "1.0", optional = true }
+serde = { version = "1.0", optional = true }
+serde_json = { version = "1.0", optional = true }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/rustwasm/gloo/tree/master/crates/utils"
 homepage = "https://github.com/rustwasm/gloo"
 categories = ["api-bindings", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 
 [dependencies]

--- a/crates/worker-macros/Cargo.toml
+++ b/crates/worker-macros/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rustwasm/gloo/tree/master/crates/worker"
 homepage = "https://github.com/rustwasm/gloo"
 license = "MIT OR Apache-2.0"
 categories = ["api-bindings", "asynchronous", "wasm"]
+rust-version = "1.56"
 
 [lib]
 proc-macro = true

--- a/crates/worker-macros/Cargo.toml
+++ b/crates/worker-macros/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rustwasm/gloo/tree/master/crates/worker"
 homepage = "https://github.com/rustwasm/gloo"
 license = "MIT OR Apache-2.0"
 categories = ["api-bindings", "asynchronous", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [lib]
 proc-macro = true

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rustwasm/gloo/tree/master/crates/worker"
 homepage = "https://github.com/rustwasm/gloo"
 license = "MIT OR Apache-2.0"
 categories = ["api-bindings", "asynchronous", "wasm"]
-rust-version = "1.56"
+rust-version = "1.64"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rustwasm/gloo/tree/master/crates/worker"
 homepage = "https://github.com/rustwasm/gloo"
 license = "MIT OR Apache-2.0"
 categories = ["api-bindings", "asynchronous", "wasm"]
+rust-version = "1.56"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Rust and WebAssembly Working Group"]
 edition = "2021"
 publish = false
-rust-version = "1.56"
+rust-version = "1.64"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -2,8 +2,9 @@
 name = "example-clock"
 version = "0.1.0"
 authors = ["Rust and WebAssembly Working Group"]
-edition = "2018"
+edition = "2021"
 publish = false
+rust-version = "1.56"
 
 [lib]
 crate-type = ["cdylib"]
@@ -18,10 +19,4 @@ console_error_panic_hook = "0.1.6"
 
 [dependencies.web-sys]
 version = "0.3.19"
-features = [
-    "console",
-    "Window",
-    "Document",
-    "Element",
-    "Node",
-]
+features = ["console", "Window", "Document", "Element", "Node"]

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Rust and WebAssembly Working Group"]
 edition = "2021"
 publish = false
-rust-version = "1.56"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Rust and WebAssembly Working Group"]
 edition = "2021"
 publish = false
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/prime/Cargo.toml
+++ b/examples/prime/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example-prime"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.56"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/prime/Cargo.toml
+++ b/examples/prime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "example-prime"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.64"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This pull request migrates to edition 2021.

Since wasm-bindgen requires 1.56, there is no benefit to keep crates at edition 2018.
Upgrading the crates to edition 2021 will enable the rust-version field which suppresses clippy for lints not available in MSRV.

I have calculated the MSRV with `cargo-msrv`, which is 1.64.
