### PR TITLE
Add traits PartialEq and Eq to EventListenerOptions, and EventListenerPhase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ### Next Version
 
 - Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
+- Add traits `PartialEq` and `Eq` to `EventListenerOptions`, and `EventListenerPhase` (#363)
 
 ### Version "0.1.1"
 

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -28,7 +28,7 @@ use web_sys::{AddEventListenerOptions, Event, EventTarget};
 /// EventListenerPhase::Bubble
 /// # ;
 /// ```
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EventListenerPhase {
     #[default]
     #[allow(missing_docs)]
@@ -91,7 +91,7 @@ impl EventListenerPhase {
 ///     passive: false,
 /// };
 /// ```
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EventListenerOptions {
     /// The phase that the event listener should be run in.
     pub phase: EventListenerPhase,


### PR DESCRIPTION
I needed to compare the options of an event listener, I don't think it hurts adding support for `PartialEq` and `Eq` for the relevant types.