### PR TITLE
Introduces the FromQuery and IntoQuery traits.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Next Version
 
 - Migrate to Edition 2021 and Apply MSRV in Cargo.toml (#360)
+- Introduces the `FromQuery` and `ToQuery` traits to allow for customizing
+  how query strings are encoded and decoded in `gloo_history`. (#364)
 
 ### Version "0.2.3"
 

--- a/crates/history/src/any.rs
+++ b/crates/history/src/any.rs
@@ -1,16 +1,13 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "query")]
-use serde::Serialize;
-
 use crate::browser::BrowserHistory;
-#[cfg(feature = "query")]
-use crate::error::HistoryResult;
 use crate::hash::HashHistory;
 use crate::history::History;
 use crate::listener::HistoryListener;
 use crate::location::Location;
 use crate::memory::MemoryHistory;
+#[cfg(feature = "query")]
+use crate::{error::HistoryResult, query::ToQuery};
 
 /// A [`History`] that provides a universal API to the underlying history type.
 #[derive(Clone, PartialEq, Debug)]
@@ -79,9 +76,13 @@ impl History for AnyHistory {
     }
 
     #[cfg(feature = "query")]
-    fn push_with_query<'a, Q>(&self, route: impl Into<Cow<'a, str>>, query: Q) -> HistoryResult<()>
+    fn push_with_query<'a, Q>(
+        &self,
+        route: impl Into<Cow<'a, str>>,
+        query: Q,
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
     {
         match self {
             Self::Browser(m) => m.push_with_query(route, query),
@@ -94,9 +95,9 @@ impl History for AnyHistory {
         &self,
         route: impl Into<Cow<'a, str>>,
         query: Q,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
     {
         match self {
             Self::Browser(m) => m.replace_with_query(route, query),
@@ -111,9 +112,9 @@ impl History for AnyHistory {
         route: impl Into<Cow<'a, str>>,
         query: Q,
         state: T,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
         T: 'static,
     {
         match self {
@@ -129,9 +130,9 @@ impl History for AnyHistory {
         route: impl Into<Cow<'a, str>>,
         query: Q,
         state: T,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
         T: 'static,
     {
         match self {

--- a/crates/history/src/error.rs
+++ b/crates/history/src/error.rs
@@ -14,4 +14,4 @@ pub enum HistoryError {
 }
 
 /// The Result type for History.
-pub type HistoryResult<T> = std::result::Result<T, HistoryError>;
+pub type HistoryResult<T, E = HistoryError> = std::result::Result<T, E>;

--- a/crates/history/src/history.rs
+++ b/crates/history/src/history.rs
@@ -1,12 +1,9 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "query")]
-use serde::Serialize;
-
-#[cfg(feature = "query")]
-use crate::error::HistoryResult;
 use crate::listener::HistoryListener;
 use crate::location::Location;
+#[cfg(feature = "query")]
+use crate::{error::HistoryResult, query::ToQuery};
 
 /// A trait to provide [`History`] access.
 ///
@@ -56,9 +53,13 @@ pub trait History: Clone + PartialEq {
 
     /// Same as `.push()` but affix the queries to the end of the route.
     #[cfg(feature = "query")]
-    fn push_with_query<'a, Q>(&self, route: impl Into<Cow<'a, str>>, query: Q) -> HistoryResult<()>
+    fn push_with_query<'a, Q>(
+        &self,
+        route: impl Into<Cow<'a, str>>,
+        query: Q,
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize;
+        Q: ToQuery;
 
     /// Same as `.replace()` but affix the queries to the end of the route.
     #[cfg(feature = "query")]
@@ -66,9 +67,9 @@ pub trait History: Clone + PartialEq {
         &self,
         route: impl Into<Cow<'a, str>>,
         query: Q,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize;
+        Q: ToQuery;
 
     /// Same as `.push_with_state()` but affix the queries to the end of the route.
     #[cfg(feature = "query")]
@@ -77,9 +78,9 @@ pub trait History: Clone + PartialEq {
         route: impl Into<Cow<'a, str>>,
         query: Q,
         state: T,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
         T: 'static;
 
     /// Same as `.replace_with_state()` but affix the queries to the end of the route.
@@ -89,9 +90,9 @@ pub trait History: Clone + PartialEq {
         route: impl Into<Cow<'a, str>>,
         query: Q,
         state: T,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
         T: 'static;
 
     /// Creates a Listener that will be notified when current state changes.

--- a/crates/history/src/lib.rs
+++ b/crates/history/src/lib.rs
@@ -12,6 +12,8 @@ mod history;
 mod listener;
 mod location;
 mod memory;
+#[cfg(feature = "query")]
+pub mod query;
 mod state;
 mod utils;
 

--- a/crates/history/src/location.rs
+++ b/crates/history/src/location.rs
@@ -2,10 +2,7 @@ use std::any::Any;
 use std::rc::Rc;
 
 #[cfg(feature = "query")]
-use serde::de::DeserializeOwned;
-
-#[cfg(feature = "query")]
-use crate::error::HistoryResult;
+use crate::{error::HistoryResult, query::FromQuery};
 
 /// A history location.
 ///
@@ -44,12 +41,12 @@ impl Location {
 
     /// Returns the queries of current URL parsed as `T`.
     #[cfg(feature = "query")]
-    pub fn query<T>(&self) -> HistoryResult<T>
+    pub fn query<T>(&self) -> HistoryResult<T::Target, T::Error>
     where
-        T: DeserializeOwned,
+        T: FromQuery,
     {
-        let query = self.query_str();
-        serde_urlencoded::from_str(query.strip_prefix('?').unwrap_or("")).map_err(|e| e.into())
+        let query = self.query_str().strip_prefix('?').unwrap_or("");
+        T::from_query(query)
     }
 
     /// Returns the hash fragment of current URL.

--- a/crates/history/src/memory.rs
+++ b/crates/history/src/memory.rs
@@ -6,17 +6,14 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::rc::Rc;
 
-#[cfg(feature = "query")]
-use serde::Serialize;
-
-#[cfg(feature = "query")]
-use crate::error::HistoryResult;
 use crate::history::History;
 use crate::listener::HistoryListener;
 use crate::location::Location;
 use crate::utils::{
     assert_absolute_path, assert_no_fragment, assert_no_query, get_id, WeakCallback,
 };
+#[cfg(feature = "query")]
+use crate::{error::HistoryResult, query::ToQuery};
 
 /// A History Stack.
 #[derive(Debug)]
@@ -210,11 +207,15 @@ impl History for MemoryHistory {
     }
 
     #[cfg(feature = "query")]
-    fn push_with_query<'a, Q>(&self, route: impl Into<Cow<'a, str>>, query: Q) -> HistoryResult<()>
+    fn push_with_query<'a, Q>(
+        &self,
+        route: impl Into<Cow<'a, str>>,
+        query: Q,
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
     {
-        let query = serde_urlencoded::to_string(query)?;
+        let query = query.to_query()?;
         let route = route.into();
 
         assert_absolute_path(&route);
@@ -240,11 +241,11 @@ impl History for MemoryHistory {
         &self,
         route: impl Into<Cow<'a, str>>,
         query: Q,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
     {
-        let query = serde_urlencoded::to_string(query)?;
+        let query = query.to_query()?;
         let route = route.into();
 
         assert_absolute_path(&route);
@@ -272,12 +273,12 @@ impl History for MemoryHistory {
         route: impl Into<Cow<'a, str>>,
         query: Q,
         state: T,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
         T: 'static,
     {
-        let query = serde_urlencoded::to_string(query)?;
+        let query = query.to_query()?;
         let route = route.into();
 
         assert_absolute_path(&route);
@@ -305,12 +306,12 @@ impl History for MemoryHistory {
         route: impl Into<Cow<'a, str>>,
         query: Q,
         state: T,
-    ) -> HistoryResult<()>
+    ) -> HistoryResult<(), Q::Error>
     where
-        Q: Serialize,
+        Q: ToQuery,
         T: 'static,
     {
-        let query = serde_urlencoded::to_string(query)?;
+        let query = query.to_query()?;
         let route = route.into();
 
         assert_absolute_path(&route);

--- a/crates/history/src/query.rs
+++ b/crates/history/src/query.rs
@@ -1,0 +1,112 @@
+//! # Encoding and decoding strategies for query strings.
+//!
+//! There are various strategies to map Rust types into HTTP query strings. The [`FromQuery`] and
+//! [`ToQuery`] encode the logic for how this encoding and decoding is performed. These traits
+//! are public as a form of dependency inversion, so that you can override the decoding and
+//! encoding strategy being used.
+//!
+//! These traits are used by the [`History`](crate::History) trait, which allows for modifying the
+//! history state, and the [`Location`](crate::Location) struct, which allows for extracting the
+//! current location (and this query).
+//!
+//! ## Default Strategy
+//!
+//! By default, any Rust type that implements [`Serialize`] or [`Deserialize`](serde::Deserialize)
+//! has an implementation of [`ToQuery`] or [`FromQuery`], respectively. This implementation uses
+//! the `serde_urlencoded` crate, which implements a standards-compliant `x-www-form-urlencoded`
+//! encoder and decoder. Some patterns are not supported by this crate, for example it is not
+//! possible to serialize arrays at the moment. If this is an issue for you, consider using the
+//! `serde_qs` crate.
+//!
+//! Example:
+//!
+//! ```rust,no_run
+//! use serde::{Serialize, Deserialize};
+//! use gloo_history::{MemoryHistory, History};
+//!
+//! #[derive(Serialize)]
+//! struct Query {
+//!     name: String,
+//! }
+//!
+//! let query = Query {
+//!     name: "user".into(),
+//! };
+//!
+//! let history = MemoryHistory::new();
+//! history.push_with_query("index.html", &query).unwrap();
+//! ```
+//!
+//! ## Custom Strategy
+//!
+//! If desired, the [`FromQuery`] and [`ToQuery`] traits can also be manually implemented on
+//! types to customize the encoding and decoding strategies. See the documentation for these traits
+//! for more detail on how this can be done.
+use crate::error::HistoryError;
+use serde::{de::DeserializeOwned, Serialize};
+use std::borrow::Cow;
+use std::convert::{AsRef, Infallible};
+
+/// Type that can be encoded into a query string.
+pub trait ToQuery {
+    /// Error that can be returned from the conversion.
+    type Error;
+
+    /// Method to encode the query into a string.
+    fn to_query(&self) -> Result<Cow<'_, str>, Self::Error>;
+}
+
+/// Type that can be decoded from a query string.
+pub trait FromQuery {
+    /// Target type after parsing.
+    type Target;
+    /// Error that can occur while parsing.
+    type Error;
+
+    /// Decode this query string into the target type.
+    fn from_query(query: &str) -> Result<Self::Target, Self::Error>;
+}
+
+impl<T: Serialize> ToQuery for T {
+    type Error = HistoryError;
+
+    fn to_query(&self) -> Result<Cow<'_, str>, Self::Error> {
+        serde_urlencoded::to_string(self)
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+}
+
+impl<T: DeserializeOwned> FromQuery for T {
+    type Target = T;
+    type Error = HistoryError;
+
+    fn from_query(query: &str) -> Result<Self::Target, Self::Error> {
+        serde_urlencoded::from_str(query).map_err(Into::into)
+    }
+}
+
+/// # Encoding for raw query strings.
+///
+/// The [`Raw`] wrapper allows for specifying a query string directly, bypassing the encoding. If
+/// you use this strategy, you need to take care to escape characters that are not allowed to
+/// appear in query strings yourself.
+#[derive(Debug, Clone)]
+pub struct Raw<T>(pub T);
+
+impl<T: AsRef<str>> ToQuery for Raw<T> {
+    type Error = Infallible;
+
+    fn to_query(&self) -> Result<Cow<'_, str>, Self::Error> {
+        Ok(self.0.as_ref().into())
+    }
+}
+
+impl<T: for<'a> From<&'a str>> FromQuery for Raw<T> {
+    type Target = T;
+    type Error = Infallible;
+
+    fn from_query(query: &str) -> Result<Self::Target, Self::Error> {
+        Ok(query.into())
+    }
+}

--- a/crates/history/tests/query.rs
+++ b/crates/history/tests/query.rs
@@ -1,0 +1,58 @@
+#![cfg(feature = "query")]
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+#[cfg(target_arch = "wasm32")]
+wasm_bindgen_test_configure!(run_in_browser);
+
+use gloo_history::query::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+struct SimpleQuery {
+    string: String,
+    number: u64,
+    optional: Option<String>,
+    boolean: bool,
+}
+
+#[test]
+fn test_raw_encode_simple() {
+    let query = Raw("name=value&other=that");
+    assert_eq!(query.to_query().unwrap(), "name=value&other=that");
+}
+
+#[test]
+fn test_raw_decode_simple() {
+    let query = "name=value&other=that";
+    let decoded = <Raw<String>>::from_query(&query).unwrap();
+    assert_eq!(decoded, query);
+}
+
+#[test]
+fn test_urlencoded_encode_simple() {
+    let query = SimpleQuery {
+        string: "test".into(),
+        number: 42,
+        optional: None,
+        boolean: true,
+    };
+
+    let encoded = query.to_query().unwrap();
+    assert_eq!(encoded, "string=test&number=42&boolean=true");
+}
+
+#[test]
+fn test_urlencoded_decode_simple() {
+    let encoded = "string=test&number=42&boolean=true";
+    let data = SimpleQuery::from_query(&encoded).unwrap();
+    assert_eq!(
+        data,
+        SimpleQuery {
+            string: "test".into(),
+            number: 42,
+            optional: None,
+            boolean: true,
+        }
+    );
+}


### PR DESCRIPTION
Introduces the `FromQuery` and `IntoQuery` traits to allow for customizing how query strings are encoded and decoded. Introduces the

- This PR is related to issue #362.
- I have taken care to make sure that this PR does not break any consumers of this crate. 

Because this PR introduces quite a few new things, allow me to walk through it an explain what is happening here.

## Query Encoding

### Previous Behaviour

The `History` trait has some methods that allow specifying a query parameter. This query parameter must implement `Serialize`. It is encoded using `serde_urlencoded`. These return a `HistoryResult<()>`, which expands to a `Result<(), HistoryError>`.

```rust
impl History {
    fn push_with_query<'a, Q>(&self, route: impl Into<Cow<'a, str>>, query: Q) -> HistoryResult<()>
        where Q: Serialize;
    fn replace_with_query<'a, Q>(&self, route: impl Into<Cow<'a, str>>, query: Q) -> HistoryResult<()>
        where Q: Serialize;
    ...
}
```

### New Behaviour

We introduce a helper trait, `IntoQuery`, to help us encode any arbitrary type that implements this into a query string. It has a configurable error (because different strategies might fail in different ways) and a method to encode that takes `&self`.

```rust
pub trait IntoQuery {
    type Error;
    fn encode(&self) -> Result<Cow<'_, str>, Self::Error>;
}
```

We also add a blanket implementation of this type for any type that implements `Serialize` with the `Error` set to `HistoryError`.

```rust
impl<T: Serialize> IntoQuery for T {
    type Error = HistoryError;

    fn encode(&self) -> Result<Cow<'_, str>, Self::Error> {
        serde_urlencoded::to_string(self)
            .map(Into::into)
            .map_err(Into::into)
    }
}
```

Now, we change the methods in the `History` trait to constrain on anything that implements `IntoQuery` instead of `Serialize`. Since we have a blanket implementation of `IntoQuery` for anything that implements `Serialize`, these two constraints are identical at this point. These now return a `IntoQuery::Error` as an error instead.

```rust
impl History {
    fn push_with_query<'a, Q>(&self, route: impl Into<Cow<'a, str>>, query: Q) -> HistoryResult<(),Q::Error>
        where Q: IntoQuery;
    fn replace_with_query<'a, Q>(&self, route: impl Into<Cow<'a, str>>, query: Q) -> HistoryResult<(), Q::Error>
        where Q: IntoQuery;
    ...
}
```

Before, it was only possible to call these methods with `Q: Serialize` and it returned a `Result<(), HistoryError>`. Now, calling it with any type that is `Q: Serialize` is still possible, and returns the same value. However, it is now possible to implement `IntoQuery` manually to override an encoding scheme. This is done with the `Qs` type and the `Raw` type.

### Breaking Changes

Because the new `History` trait API is a superset of the previous API, this does not constitute a breaking change for consumers of this trait. It does however change the trait, which means that anyone who manually implements the `History` trait for a custom type (I don't know why anyone would do that, but you could) needs to adjust their implementation slightly. It might be worth looking into [sealing the History trait](https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/) for future-proofing it, otherwise any change, even addition of a method, is a potential (hypothetical) breaking change.

## Query Decoding

### Previous Behaviour

Query decoding happens in the `Location` struct, which has a `query` method.

```rust
impl Location {
        pub fn query<T>(&self) -> HistoryResult<T> where T: DeserializeOwned;
}
```

### New Behaviour

We introduce a trait to capture the idea of decoding a query string. This has a `Target` type parameter, so that a `MyCustomStrategy` can decode into a `String` if it wanted to, and an `Error` parameter, as well as a `decode()` method.

```rust
pub trait FromQuery {
    type Target;
    type Error;
    fn decode(query: &str) -> Result<Self::Target, Self::Error>;
}
```

Again, we add a blanket implementation for any T that implements `DeserializeOwned`.

```rust
impl<T: DeserializeOwned> FromQuery for T {
    type Target = T;
    type Error = HistoryError;

    fn decode(query: &str) -> Result<Self::Target, Self::Error> {
        serde_urlencoded::from_str(query).map_err(Into::into)
    }
}
```

With this, we change the method to return a `T::Target` and an `T::Error` instead.

```rust
impl Location {
pub fn query<T>(&self) -> HistoryResult<T::Target, T::Error> where T: FromQuery;
```

With this change, all previous invocations still work the exact same way. However, we can now implement `FromQuery` for custom types to use a custom decoding strategy.

### Breaking Changes

Since this is not a trait, and the new definition is a superset of the old, this does not constitute a breaking change.

## Tests

Tests have been added for the traits. The test coverage exceeds 80%.

## Documentation

Documentation has been added, however it could still be improved with more examples.

