### PR TITLE
History id start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,7 @@ dependencies = [
  "futures",
  "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "gloo-utils 0.2.0",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,8 +402,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -567,6 +569,7 @@ dependencies = [
 name = "gloo-history"
 version = "0.2.0"
 dependencies = [
+ "getrandom",
  "gloo-events 0.2.0",
  "gloo-timers 0.3.0",
  "gloo-utils 0.2.0",

--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -24,6 +24,9 @@ thiserror = { version = "1.0", optional = true }
 version = "0.3"
 features = ["History", "Window", "Location", "Url"]
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2.10", features = ["js"] }
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 gloo-timers = { version = "0.3.0", features = ["futures"], path = "../timers" }


### PR DESCRIPTION
This should fix https://github.com/rustwasm/gloo/issues/369 most of the time.

Without any changes the Cargo.lock changed after building, that's in the first commit (I can squish it into one).

Using window.performance.now() is not an option because it starts the time when the website loads and thats why I've added js-sys as a dependency.

Everything else should be documented in the code.

Instead of OnceLock it's also possible to use the unprotected AtomicU32 as before and a Once to initialize it.

Edit: the option with Once is available with 1.64 - which I didn't realize that it has/should be compatible with.
