### PR TITLE
fix(gloo-net): remove bug-abling EventSource Clone implementation

### DIFF
--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -50,7 +50,6 @@ use web_sys::MessageEvent;
 
 /// Wrapper around browser's EventSource API. Dropping
 /// this will close the underlying event source.
-#[derive(Clone)]
 pub struct EventSource {
     es: web_sys::EventSource,
 }


### PR DESCRIPTION
# PR Content

Remove the `Clone` derive/impl for the `EventSource` .

# Reasoning

After discussing https://github.com/rustwasm/gloo/discussions/409, it seems that the implementation of Clone for `EventSource` is a bug.

To summarize the situation:

`EventSource` implements `Drop` and will disconnect the internal connection upon triggering this mechanism.
However, when cloning this structure, if any instance of `EventSource` is going out of scope, all of the instances will have their internal connection disconnected.

An example of a situation where this can be unexpected to the user and not straight forward:
- Using `yewdux` to manage a mutable global state. `yewdux`'s state will need to have the structs field that impl `Clone`. Hence here using `EventSource` in its previous version, would be allowed, without any additional wrapper. However, internally `yewdux` clone's and drops the state, hence destroying the precious connection and rendering the `EventSource` virtually unusable, but without any explanation to the user.
