### PR TITLE
Fix broken docs link

### DIFF
--- a/crates/worker/src/actor/traits.rs
+++ b/crates/worker/src/actor/traits.rs
@@ -23,7 +23,7 @@ pub trait Worker: Sized {
 
     /// New bridge created.
     ///
-    /// When a new bridge is created by [`WorkerSpawner::spawn`](crate::spawner::WorkerSpawner)
+    /// When a new bridge is created by [`WorkerSpawner::spawn`](crate::WorkerSpawner)
     /// or [`WorkerBridge::fork`](crate::WorkerBridge::fork),
     /// the worker will be notified the [`HandlerId`] of the created bridge via this method.
     fn connected(&mut self, scope: &WorkerScope<Self>, id: HandlerId) {


### PR DESCRIPTION
[WorkerSpawner](https://docs.rs/gloo-worker/latest/gloo_worker/struct.WorkerSpawner.html) is at `crate::WorkerSpawner`, not `crate::spawner::WorkerSpawner`

Fixes #449