### PR TITLE
Recognise that connection handling is a developer concern

### DIFF
--- a/crates/console/src/lib.rs
+++ b/crates/console/src/lib.rs
@@ -25,7 +25,6 @@ mod macros;
 mod timer;
 
 pub use counter::Counter;
-pub use macros::*;
 pub use timer::Timer;
 
 #[doc(hidden)]

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -134,15 +134,8 @@ impl EventSource {
             .map_err(js_to_js_error)?;
 
         let error_callback: Closure<dyn FnMut(web_sys::Event)> = {
-            Closure::wrap(Box::new(move |e: web_sys::Event| {
-                let is_connecting = e
-                    .current_target()
-                    .map(|target| target.unchecked_into::<web_sys::EventSource>())
-                    .map(|es| es.ready_state() == web_sys::EventSource::CONNECTING)
-                    .unwrap_or(false);
-                if !is_connecting {
-                    let _ = message_sender.unbounded_send(StreamMessage::ErrorEvent);
-                };
+            Closure::wrap(Box::new(move |_| {
+                let _ = message_sender.unbounded_send(StreamMessage::ErrorEvent);
             }) as Box<dyn FnMut(web_sys::Event)>)
         };
 

--- a/crates/net/tests/http.rs
+++ b/crates/net/tests/http.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen_test::*;
 
-#[cfg(feature = "browser_test")]
+#[cfg(feature = "browser-test")]
 wasm_bindgen_test_configure!(run_in_browser);
 
 static HTTPBIN_URL: Lazy<&'static str> =

--- a/crates/net/tests/query.rs
+++ b/crates/net/tests/query.rs
@@ -1,7 +1,7 @@
 use gloo_net::http::QueryParams;
 use wasm_bindgen_test::*;
 
-#[cfg(feature = "browser_test")]
+#[cfg(feature = "browser-test")]
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
Removes the logic to test for a connection error with Server Sent Events.

My original attraction to SSE was that the browser would handle the connection and re-connect if it can. It turns out, after many years of using SSE(!), I learn that browsers are not consistent in their reconnection policy. For a start, browsers can decide how long to wait before re-connecting.

SSE will re-connect automatically under certain conditions, but again there's no specification in terms of what these conditions should be. For example, an "503 - service unavailable" does not seem to cause a re-connect for Chrome, yet this is often a transient error.

In the end, you're left with implementing your own connection handling anyway. We therefore push the testing of the connecting state back on the developer.

I also clean up a couple of compiler/clippy warnings along the way, and fix the feature flag test for testing the net modules.