### PR TITLE
fix: update documented wasm-pack commands used for testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ cargo build -p my-particular-crate
 To run headless browser tests for a particular crate:
 
 ```shell
-wasm-pack test crates/my-particular-crate --headless --firefox # or --safari or --chrome
+wasm-pack test --headless --firefox crates/my-particular-crate # or --safari or --chrome
 ```
 
 #### Wasm Node Tests
@@ -87,7 +87,7 @@ wasm-pack test crates/my-particular-crate --headless --firefox # or --safari or 
 To run tests in Node.js:
 
 ```shell
-wasm-pack test crates/my-particular-crate --node
+wasm-pack test --node crates/my-particular-crate
 ```
 
 #### Non-Wasm Tests


### PR DESCRIPTION
The documentation states

```bash
wasm-pack test crates/my-particular-crate --headless --firefox
```

but it should be 

```bash
wasm-pack test --headless --firefox crates/my-particular-crate
```

otherwise wasm-pack complains:

```bash
Error: Must specify at least one of `--node`, `--chrome`, `--firefox`, or `--safari`
Caused by: Must specify at least one of `--node`, `--chrome`, `--firefox`, or `--safari`
```