### PR TITLE
RequestBuilder::build creates a url with extra '& at the end

### DIFF
--- a/crates/net/src/http/request.rs
+++ b/crates/net/src/http/request.rs
@@ -208,9 +208,16 @@ impl TryFrom<RequestBuilder> for Request {
         // absolute URL through creating a web_sys::Request object.
         let request = web_sys::Request::new_with_str(&value.url).map_err(js_to_error)?;
         let url = web_sys::Url::new(&request.url()).map_err(js_to_error)?;
-        let combined_query = match url.search().as_str() {
-            "" => value.query.to_string(),
-            _ => format!("{}&{}", url.search(), value.query),
+
+        let url_search = url.search();
+        let combined_query = if url_search.is_empty() {
+            value.query.to_string()
+        } else {
+            let mut query = value.query.to_string();
+            if !query.is_empty() {
+                query = format!("&{query}");
+            }
+            format!("{url_search}{query}")
         };
         url.set_search(&combined_query);
 

--- a/crates/net/src/websocket/futures.rs
+++ b/crates/net/src/websocket/futures.rs
@@ -352,11 +352,24 @@ impl PinnedDrop for WebSocket {
 
 #[cfg(test)]
 mod tests {
+    use crate::http::Request;
+
     use super::*;
     use futures::{SinkExt, StreamExt};
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    async fn can_build_url_with_parameters_and_ampersand_is_not_added() {
+        let url = "http://something.com/get?param1=value1";
+        let request = Request::get(url).build().unwrap();
+        assert_eq!(
+            request.url(),
+            url,
+            "url of the built request should be equal to the parameter provided {url}"
+        );
+    }
 
     #[wasm_bindgen_test]
     async fn websocket_works() {


### PR DESCRIPTION
When doing something like

```rust
let url = "http://something.com/get?param1=value1";
let request = Request::get(url).build().unwrap();
```

the request created will target `http://something.com/get?param1=value1&` and not the original url, `http://something.com/get?param1=value1` (note there is an '&' added).

I'm providing a test and the fix for it.
Sorry I couldn't figure out how to put the test where it should be going (somewhere in http?)