### PR TITLE
Prevent panic in `HashHistory::location()` on malformed hash URLs

### DIFF
--- a/crates/history/Cargo.toml
+++ b/crates/history/Cargo.toml
@@ -23,7 +23,7 @@ wasm-bindgen = "0.2.114"
 
 [dependencies.web-sys]
 version = "0.3"
-features = ["History", "Window", "Location", "Url"]
+features = ["console", "History", "Window", "Location", "Url"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.17", features = ["js"] }

--- a/crates/history/src/hash.rs
+++ b/crates/history/src/hash.rs
@@ -16,7 +16,16 @@ use crate::{error::HistoryResult, query::ToQuery};
 ///
 /// # Panics
 ///
-/// HashHistory does not support relative paths and will panic if routes are not starting with `/`.
+/// The `push` and `replace` family of methods do not support relative paths
+/// and will panic if the provided route does not start with `/`.
+///
+/// # Hash Normalization
+///
+/// If the URL hash is manually edited by the user to a value that does not
+/// start with `#/`, calling `location()` will **not** panic. Instead, it will:
+/// 1. Log a warning to the browser console.
+/// 2. Normalize the hash by prepending `/` if missing.
+/// 3. Silently correct the URL in the address bar via `replaceState`.
 #[derive(Clone, PartialEq)]
 pub struct HashHistory {
     inner: BrowserHistory,
@@ -195,19 +204,29 @@ impl History for HashHistory {
 
     fn location(&self) -> Location {
         let inner_loc = self.inner.location();
-        // We strip # from hash.
-        let hash_url = inner_loc.hash().chars().skip(1).collect::<String>();
 
-        assert_absolute_path(&hash_url);
+        // Strip the leading '#' from the hash.
+        let raw_hash = inner_loc.hash().strip_prefix('#').unwrap_or("").to_string();
+
+        // Normalize: ensure it starts with '/'. Log a warning if it didn't.
+        let needs_correction = raw_hash.is_empty() || !raw_hash.starts_with('/');
+        let normalized = Self::normalize_hash(&raw_hash);
 
         let hash_url = Url::new_with_base(
-            &hash_url,
+            &normalized,
             &window()
                 .location()
                 .href()
                 .expect_throw("failed to get location href."),
         )
-        .expect_throw("failed to get make url");
+        .expect_throw("failed to make url");
+
+        // Auto-correct the URL in the address bar so it stays canonical.
+        if needs_correction {
+            let url = Self::get_url();
+            url.set_hash(&format!("#{normalized}"));
+            self.inner.replace(url.href());
+        }
 
         Location {
             path: hash_url.pathname().into(),
@@ -223,6 +242,33 @@ impl HashHistory {
     /// Creates a new [`HashHistory`]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Takes the raw content after '#' and ensures it starts with '/'.
+    /// If it doesn't, prepends '/' and logs a warning.
+    /// If it is empty, returns "/".
+    fn normalize_hash(raw: &str) -> String {
+        if raw.is_empty() {
+            web_sys::console::warn_1(
+                &"[gloo_history] HashHistory: URL hash is empty, defaulting to '/'. \
+                  The hash was auto-corrected to '#/'."
+                    .into(),
+            );
+            "/".to_string()
+        } else if !raw.starts_with('/') {
+            web_sys::console::warn_1(
+                &format!(
+                    "[gloo_history] HashHistory: URL hash '#{}' does not start with '/'. \
+                     The hash was normalized to '#/{}'. \
+                     Ensure hash-based routes always begin with '#/'.",
+                    raw, raw
+                )
+                .into(),
+            );
+            format!("/{raw}")
+        } else {
+            raw.to_string()
+        }
     }
 
     fn get_url() -> Url {

--- a/crates/history/tests/hash_history.rs
+++ b/crates/history/tests/hash_history.rs
@@ -51,3 +51,39 @@ async fn history_works() {
     delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
     delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-b").await;
 }
+
+#[test]
+async fn location_does_not_panic_on_malformed_hash() {
+    let history = HashHistory::new();
+
+    // Simulate the user manually editing the URL bar to a hash without a leading '/'
+    window().location().set_hash("no-leading-slash").unwrap();
+
+    // This must NOT panic
+    let location = history.location();
+
+    // The path should have been normalized with a leading '/'
+    assert_eq!(location.path(), "/no-leading-slash");
+
+    // The URL should have been auto-corrected
+    delayed_assert_eq(
+        || window().location().hash().unwrap(),
+        || "#/no-leading-slash",
+    )
+    .await;
+}
+
+#[test]
+async fn location_does_not_panic_on_empty_hash() {
+    let history = HashHistory::new();
+
+    // Simulate the user clearing the hash entirely
+    window().location().set_hash("").unwrap();
+
+    let location = history.location();
+
+    assert_eq!(location.path(), "/");
+
+    // The URL should have been auto-corrected
+    delayed_assert_eq(|| window().location().hash().unwrap(), || "#/").await;
+}

--- a/crates/history/tests/hash_history.rs
+++ b/crates/history/tests/hash_history.rs
@@ -8,6 +8,9 @@ wasm_bindgen_test_configure!(run_in_browser);
 mod utils;
 use utils::delayed_assert_eq;
 
+// All assertions live in a single test because HashHistory is a thread-local
+// singleton backed by a shared browser URL, so separate tests would leak
+// state into each other depending on execution order.
 #[test]
 async fn history_works() {
     let history = HashHistory::new();
@@ -50,40 +53,24 @@ async fn history_works() {
     }
     delayed_assert_eq(|| window().location().pathname().unwrap(), || "/").await;
     delayed_assert_eq(|| window().location().hash().unwrap(), || "#/path-b").await;
-}
 
-#[test]
-async fn location_does_not_panic_on_malformed_hash() {
-    let history = HashHistory::new();
-
-    // Simulate the user manually editing the URL bar to a hash without a leading '/'
+    // Malformed hash: simulate user editing the URL bar to a hash without '/'
     window().location().set_hash("no-leading-slash").unwrap();
 
-    // This must NOT panic
     let location = history.location();
-
-    // The path should have been normalized with a leading '/'
     assert_eq!(location.path(), "/no-leading-slash");
 
-    // The URL should have been auto-corrected
     delayed_assert_eq(
         || window().location().hash().unwrap(),
         || "#/no-leading-slash",
     )
     .await;
-}
 
-#[test]
-async fn location_does_not_panic_on_empty_hash() {
-    let history = HashHistory::new();
-
-    // Simulate the user clearing the hash entirely
+    // Empty hash: simulate user clearing the hash entirely
     window().location().set_hash("").unwrap();
 
     let location = history.location();
-
     assert_eq!(location.path(), "/");
 
-    // The URL should have been auto-corrected
     delayed_assert_eq(|| window().location().hash().unwrap(), || "#/").await;
 }


### PR DESCRIPTION
`HashHistory::location()` called assert_absolute_path on the URL hash, which panicked if the hash didn't start with #/. Users can edit the URL bar at any time to produce hashes like #aaa or just #, crashing the application on the next location() call.

Replace the `assert_absolute_path` call in `location()` with graceful normalization:

 - If the hash is empty or doesn't start with `/`, prepend `/` (or default to `/` if empty).
 - Log a warning to the browser console so developers can diagnose unexpected routing behavior.
 - Silently correct the URL in the address bar via `replaceState` so it stays in canonical `#/...` form.

The `push`/`replace` methods continue to assert, since those are developer-controlled inputs where a relative path is always a bug.

This approach mirrors how every mainstream JS router library handles the same problem. None of them throw on a malformed hash:

- **`history` v4 / React Router 5** ([source](https://github.com/remix-run/history/blob/v4/modules/createHashHistory.js)): `addLeadingSlash` normalizes on read; `replaceHashPath` auto-corrects the URL on every `hashchange`.
- **`history` v5 / React Router 6** ([source](https://github.com/remix-run/history/blob/dev/packages/history/index.ts)): `parsePath` with destructuring defaults (`pathname = "/"`) silently falls back to root.
- **React Router v7** ([source](https://github.com/remix-run/react-router/blob/main/packages/react-router/lib/router/history.ts)): Explicit `pathname = "/" + pathname` prepend with a code comment explaining why.
- **Vue Router 3** ([source](https://github.com/vuejs/vue-router/blob/dev/src/history/hash.js)): `ensureSlash()` runs on every `hashchange`, prepends `/` if missing, replaces the URL, and aborts the transition.
- **Vue Router 4** ([source](https://github.com/vuejs/router/blob/main/packages/router/src/history/hash.ts)): `createWebHashHistory` delegates to `createWebHistory` with a `#`-based base, unifying URL parsing across modes.


Fixes #470

---

This prior art was researched by Claude and used to implement the fix in this PR