### PR TITLE
fix: propagate unwind safety to user callbacks across all gloo crates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,6 +119,43 @@ jobs:
             wasm-pack test --node crates/$x --no-default-features
           done
 
+  panic_unwind_build:
+    name: Build with -Cpanic=unwind
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Recent Rust nightlies with LLVM 22 are temporarily broken with
+      # `panic=unwind` (see wasm-bindgen/wasm-bindgen#4929). Pin to a known-good
+      # nightly to avoid flapping.
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-01-28
+          target: wasm32-unknown-unknown
+          components: rust-src
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-panic-unwind-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-panic-unwind-
+            cargo-${{ runner.os }}-
+
+      # Verify gloo-timers (and any other crate that hosts user closures via
+      # `Closure::wrap` / `Closure::once`) still builds cleanly under
+      # `panic = "unwind"` against the new `MaybeUnwindSafe` bounds added in
+      # wasm-bindgen 0.2.117+. Catches downstream regressions like
+      # https://github.com/MattiasBuelens/wasm-streams/pull/35 from creeping in.
+      - name: Build crates with panic=unwind
+        env:
+          RUSTFLAGS: '-Cpanic=unwind'
+        run: |
+          cargo build -p gloo-timers --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
+
   test-history-wasi:
     name: Test gloo-history WASI
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,6 +155,7 @@ jobs:
           RUSTFLAGS: '-Cpanic=unwind'
         run: |
           cargo build -p gloo-timers --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
+          cargo build -p gloo-timers --features futures --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
 
   test-history-wasi:
     name: Test gloo-history WASI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,23 +142,10 @@ jobs:
             cargo-${{ runner.os }}-panic-unwind-
             cargo-${{ runner.os }}-
 
-      # Verify every gloo crate that wraps user closures via `Closure::wrap`
-      # / `Closure::once` still builds cleanly under `panic = "unwind"`
-      # against the `MaybeUnwindSafe` bounds added in wasm-bindgen 0.2.117+.
-      # Catches downstream regressions like
-      # https://github.com/MattiasBuelens/wasm-streams/pull/35 from creeping
-      # in. The crates listed here are the ones that host wasm-bindgen
-      # closures; the others have no relevant code path.
       - name: Build crates with panic=unwind
         env:
           RUSTFLAGS: '-Cpanic=unwind'
-        run: |
-          cargo build -p gloo-timers --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
-          cargo build -p gloo-timers --features futures --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
-          cargo build -p gloo-events --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
-          cargo build -p gloo-render --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
-          cargo build -p gloo-net --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
-          cargo build -p gloo-worker --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
+        run: cargo build -p gloo-timers -p gloo-events -p gloo-render -p gloo-net -p gloo-worker --all-features --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
 
   test-history-wasi:
     name: Test gloo-history WASI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,12 +125,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Recent Rust nightlies with LLVM 22 are temporarily broken with
-      # `panic=unwind` (see wasm-bindgen/wasm-bindgen#4929). Pin to a known-good
-      # nightly to avoid flapping.
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-01-28
+          toolchain: nightly
           target: wasm32-unknown-unknown
           components: rust-src
 
@@ -145,17 +142,23 @@ jobs:
             cargo-${{ runner.os }}-panic-unwind-
             cargo-${{ runner.os }}-
 
-      # Verify gloo-timers (and any other crate that hosts user closures via
-      # `Closure::wrap` / `Closure::once`) still builds cleanly under
-      # `panic = "unwind"` against the new `MaybeUnwindSafe` bounds added in
-      # wasm-bindgen 0.2.117+. Catches downstream regressions like
-      # https://github.com/MattiasBuelens/wasm-streams/pull/35 from creeping in.
+      # Verify every gloo crate that wraps user closures via `Closure::wrap`
+      # / `Closure::once` still builds cleanly under `panic = "unwind"`
+      # against the `MaybeUnwindSafe` bounds added in wasm-bindgen 0.2.117+.
+      # Catches downstream regressions like
+      # https://github.com/MattiasBuelens/wasm-streams/pull/35 from creeping
+      # in. The crates listed here are the ones that host wasm-bindgen
+      # closures; the others have no relevant code path.
       - name: Build crates with panic=unwind
         env:
           RUSTFLAGS: '-Cpanic=unwind'
         run: |
           cargo build -p gloo-timers --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
           cargo build -p gloo-timers --features futures --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
+          cargo build -p gloo-events --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
+          cargo build -p gloo-render --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
+          cargo build -p gloo-net --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
+          cargo build -p gloo-worker --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind
 
   test-history-wasi:
     name: Test gloo-history WASI

--- a/crates/events/src/lib.rs
+++ b/crates/events/src/lib.rs
@@ -15,6 +15,24 @@ use wasm_bindgen::closure::Closure;
 use wasm_bindgen::{JsCast, UnwrapThrowExt};
 use web_sys::{AddEventListenerOptions, Event, EventTarget};
 
+/// Bound carrying the unwind-safety requirement on [`EventListener`] callbacks.
+///
+/// Under `panic = "unwind"` on wasm the callback is invoked across a
+/// `catch_unwind` boundary inside `wasm_bindgen`, so this resolves to
+/// [`std::panic::UnwindSafe`]. Under any other panic strategy it is a no-op
+/// blanket. Wrap non-`UnwindSafe` captures in [`std::panic::AssertUnwindSafe`]
+/// at the call site.
+#[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+pub trait CallbackUnwindSafe: std::panic::UnwindSafe {}
+#[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+impl<T: std::panic::UnwindSafe> CallbackUnwindSafe for T {}
+
+#[doc(hidden)]
+#[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+pub trait CallbackUnwindSafe {}
+#[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+impl<T> CallbackUnwindSafe for T {}
+
 /// Specifies whether the event listener is run during the capture or bubble phase.
 ///
 /// The official specification has [a good explanation](https://www.w3.org/TR/DOM-Level-3-Events/#event-flow)
@@ -331,9 +349,18 @@ impl EventListener {
     pub fn new<S, F>(target: &EventTarget, event_type: S, callback: F) -> Self
     where
         S: Into<Cow<'static, str>>,
-        F: FnMut(&Event) + 'static,
+        F: FnMut(&Event) + 'static + CallbackUnwindSafe,
     {
-        let callback = Closure::wrap(Box::new(callback) as Box<dyn FnMut(&Event)>);
+        // The `Box<F> as Box<dyn FnMut(&Event)>` coercion erases the static
+        // `UnwindSafe` bound that wasm-bindgen 0.2.117+ requires under
+        // `panic = "unwind"`. The `CallbackUnwindSafe` bound on `F` has
+        // enforced unwind safety at the call site, so the internal
+        // `_assert_unwind_safe` is sound.
+        let inner = Box::new(callback) as Box<dyn FnMut(&Event)>;
+        #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+        let callback = Closure::wrap_assert_unwind_safe(inner);
+        #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+        let callback = Closure::wrap(inner);
 
         NEW_OPTIONS.with(move |options| {
             Self::raw_new(
@@ -371,8 +398,13 @@ impl EventListener {
     pub fn once<S, F>(target: &EventTarget, event_type: S, callback: F) -> Self
     where
         S: Into<Cow<'static, str>>,
-        F: FnOnce(&Event) + 'static,
+        F: FnOnce(&Event) + 'static + CallbackUnwindSafe,
     {
+        // See `EventListener::new` for the rationale on the cfg-gated
+        // `_assert_unwind_safe` variant.
+        #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+        let callback = Closure::once_assert_unwind_safe(callback);
+        #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
         let callback = Closure::once(callback);
 
         ONCE_OPTIONS.with(move |options| {
@@ -450,9 +482,14 @@ impl EventListener {
     ) -> Self
     where
         S: Into<Cow<'static, str>>,
-        F: FnMut(&Event) + 'static,
+        F: FnMut(&Event) + 'static + CallbackUnwindSafe,
     {
-        let callback = Closure::wrap(Box::new(callback) as Box<dyn FnMut(&Event)>);
+        // See `EventListener::new` for the rationale.
+        let inner = Box::new(callback) as Box<dyn FnMut(&Event)>;
+        #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+        let callback = Closure::wrap_assert_unwind_safe(inner);
+        #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+        let callback = Closure::wrap(inner);
 
         Self::raw_new(
             target,
@@ -514,8 +551,12 @@ impl EventListener {
     ) -> Self
     where
         S: Into<Cow<'static, str>>,
-        F: FnOnce(&Event) + 'static,
+        F: FnOnce(&Event) + 'static + CallbackUnwindSafe,
     {
+        // See `EventListener::new` for the rationale.
+        #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+        let callback = Closure::once_assert_unwind_safe(callback);
+        #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
         let callback = Closure::once(callback);
 
         Self::raw_new(

--- a/crates/net/src/eventsource/futures.rs
+++ b/crates/net/src/eventsource/futures.rs
@@ -177,7 +177,7 @@ impl EventSource {
         let message_callback: Closure<dyn FnMut(MessageEvent)> = {
             let event_type = event_type.clone();
             let sender = message_sender.clone();
-            Closure::wrap(Box::new(move |e: MessageEvent| {
+            wrap_internal!(Box::new(move |e: MessageEvent| {
                 let event_type = event_type.clone();
                 let _ = sender.unbounded_send(StreamMessage::Message(event_type, e));
             }) as Box<dyn FnMut(MessageEvent)>)
@@ -192,7 +192,7 @@ impl EventSource {
             .map_err(js_to_js_error)?;
 
         let error_callback: Closure<dyn FnMut(web_sys::Event)> = {
-            Closure::wrap(Box::new(move |e: web_sys::Event| {
+            wrap_internal!(Box::new(move |e: web_sys::Event| {
                 let is_connecting = e
                     .current_target()
                     .map(|target| target.unchecked_into::<web_sys::EventSource>())

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -82,6 +82,21 @@
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+// wasm-bindgen 0.2.117+ requires `MaybeUnwindSafe` on closure inputs under
+// `panic = "unwind"`. The `Box::new(...) as Box<dyn Fn*>` coercion used to
+// construct internal event callbacks erases any static `UnwindSafe` bound,
+// so we route through `Closure::wrap_assert_unwind_safe` instead. The
+// assertion is sound: every callback in this crate only forwards to ops on
+// state we exclusively own — lock-free `mpsc::UnboundedSender` pushes and
+// single-shot `Option<Waker>` takes/wakes — so a panic across the
+// `catch_unwind` boundary leaves observers seeing only states that are
+// legitimately reachable (a missing wake, a missing message). On any other
+// panic strategy this reduces to plain `Closure::wrap`.
+#[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+macro_rules! wrap_internal { ($e:expr) => { wasm_bindgen::closure::Closure::wrap_assert_unwind_safe($e) } }
+#[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+macro_rules! wrap_internal { ($e:expr) => { wasm_bindgen::closure::Closure::wrap($e) } }
+
 mod error;
 #[cfg(feature = "eventsource")]
 #[cfg_attr(docsrs, doc(cfg(feature = "eventsource")))]

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -93,9 +93,17 @@
 // legitimately reachable (a missing wake, a missing message). On any other
 // panic strategy this reduces to plain `Closure::wrap`.
 #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
-macro_rules! wrap_internal { ($e:expr) => { wasm_bindgen::closure::Closure::wrap_assert_unwind_safe($e) } }
+macro_rules! wrap_internal {
+    ($e:expr) => {
+        wasm_bindgen::closure::Closure::wrap_assert_unwind_safe($e)
+    };
+}
 #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
-macro_rules! wrap_internal { ($e:expr) => { wasm_bindgen::closure::Closure::wrap($e) } }
+macro_rules! wrap_internal {
+    ($e:expr) => {
+        wasm_bindgen::closure::Closure::wrap($e)
+    };
+}
 
 mod error;
 #[cfg(feature = "eventsource")]

--- a/crates/net/src/websocket/futures.rs
+++ b/crates/net/src/websocket/futures.rs
@@ -133,7 +133,7 @@ impl WebSocket {
 
         let open_callback: Closure<dyn FnMut()> = {
             let waker = Rc::clone(&waker);
-            Closure::wrap(Box::new(move || {
+            wrap_internal!(Box::new(move || {
                 if let Some(waker) = waker.borrow_mut().take() {
                     waker.wake();
                 }
@@ -151,7 +151,7 @@ impl WebSocket {
 
         let message_callback: Closure<dyn FnMut(MessageEvent)> = {
             let sender = sender.clone();
-            Closure::wrap(Box::new(move |e: MessageEvent| {
+            wrap_internal!(Box::new(move |e: MessageEvent| {
                 let msg = parse_message(e);
                 let _ = sender.unbounded_send(StreamMessage::Message(msg));
             }) as Box<dyn FnMut(MessageEvent)>)
@@ -163,7 +163,7 @@ impl WebSocket {
         let error_callback: Closure<dyn FnMut(web_sys::Event)> = {
             let sender = sender.clone();
             let waker = Rc::clone(&waker);
-            Closure::wrap(Box::new(move |_e: web_sys::Event| {
+            wrap_internal!(Box::new(move |_e: web_sys::Event| {
                 if let Some(waker) = waker.borrow_mut().take() {
                     waker.wake();
                 }
@@ -175,7 +175,7 @@ impl WebSocket {
             .map_err(js_to_js_error)?;
 
         let close_callback: Closure<dyn FnMut(web_sys::CloseEvent)> = {
-            Closure::wrap(Box::new(move |e: web_sys::CloseEvent| {
+            wrap_internal!(Box::new(move |e: web_sys::CloseEvent| {
                 let close_event = CloseEvent {
                     code: e.code(),
                     reason: e.reason(),

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -77,9 +77,13 @@ where
             callback(time);
         }) as Box<dyn Fn(JsValue)>;
         #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
-        { Closure::wrap_assert_unwind_safe(inner) }
+        {
+            Closure::wrap_assert_unwind_safe(inner)
+        }
         #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
-        { Closure::wrap(inner) }
+        {
+            Closure::wrap(inner)
+        }
     };
 
     let render_id = web_sys::window()

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -9,6 +9,25 @@ use std::rc::Rc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::prelude::*;
 
+/// Bound carrying the unwind-safety requirement on [`request_animation_frame`]
+/// callbacks.
+///
+/// Under `panic = "unwind"` on wasm the callback is invoked across a
+/// `catch_unwind` boundary inside `wasm_bindgen`, so this resolves to
+/// [`std::panic::UnwindSafe`]. Under any other panic strategy it is a no-op
+/// blanket. Wrap non-`UnwindSafe` captures in [`std::panic::AssertUnwindSafe`]
+/// at the call site.
+#[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+pub trait CallbackUnwindSafe: std::panic::UnwindSafe {}
+#[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+impl<T: std::panic::UnwindSafe> CallbackUnwindSafe for T {}
+
+#[doc(hidden)]
+#[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+pub trait CallbackUnwindSafe {}
+#[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+impl<T> CallbackUnwindSafe for T {}
+
 /// Handle for [`request_animation_frame`].
 #[derive(Debug)]
 pub struct AnimationFrame {
@@ -40,16 +59,27 @@ impl Drop for AnimationFrame {
 /// [MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestAnimationFrame)
 pub fn request_animation_frame<F>(callback_once: F) -> AnimationFrame
 where
-    F: FnOnce(f64) + 'static,
+    F: FnOnce(f64) + 'static + CallbackUnwindSafe,
 {
     let callback_wrapper = Rc::new(RefCell::new(Some(CallbackWrapper(Box::new(callback_once)))));
+    // The internal trampoline captures `Rc<RefCell<Option<CallbackWrapper>>>`
+    // which is not `UnwindSafe`. Asserting unwind safety here is sound: the
+    // `borrow_mut().take()` releases the borrow before invoking the user
+    // closure, and a panic inside the user closure leaves the cell holding
+    // `None` — a valid post-fire state. `Drop` checks `is_some()` and skips
+    // cancellation when the slot is already empty. The `CallbackUnwindSafe`
+    // bound on the public API enforces unwind safety at the call site.
     let callback: Closure<dyn Fn(JsValue)> = {
         let callback_wrapper = Rc::clone(&callback_wrapper);
-        Closure::wrap(Box::new(move |v: JsValue| {
+        let inner = Box::new(move |v: JsValue| {
             let time: f64 = v.as_f64().unwrap_or(0.0);
             let callback = callback_wrapper.borrow_mut().take().unwrap().0;
             callback(time);
-        }))
+        }) as Box<dyn Fn(JsValue)>;
+        #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+        { Closure::wrap_assert_unwind_safe(inner) }
+        #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+        { Closure::wrap(inner) }
     };
 
     let render_id = web_sys::window()

--- a/crates/timers/Cargo.toml
+++ b/crates/timers/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = { workspace = true }
 features = ["futures"]
 
 [dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = "0.2.117"
 js-sys = { workspace = true }
 futures-core = { version = "0.3", optional = true }
 futures-channel = { version = "0.3", optional = true }

--- a/crates/timers/Cargo.toml
+++ b/crates/timers/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = { workspace = true }
 features = ["futures"]
 
 [dependencies]
-wasm-bindgen = "0.2.117"
+wasm-bindgen = "0.2"
 js-sys = { workspace = true }
 futures-core = { version = "0.3", optional = true }
 futures-channel = { version = "0.3", optional = true }

--- a/crates/timers/src/callback.rs
+++ b/crates/timers/src/callback.rs
@@ -4,6 +4,32 @@ use js_sys::Function;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::{JsCast, JsValue};
 
+/// Bound carrying the unwind-safety requirement on [`Timeout::new`] /
+/// [`Interval::new`] callbacks.
+///
+/// Under `panic = "unwind"` on wasm the callback is invoked across a
+/// `catch_unwind` boundary inside `wasm_bindgen`, so this resolves to
+/// [`std::panic::UnwindSafe`]. Under any other panic strategy it is a no-op
+/// blanket. Wrap non-`UnwindSafe` captures in [`std::panic::AssertUnwindSafe`]
+/// at the call site.
+#[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+pub trait CallbackUnwindSafe: std::panic::UnwindSafe {}
+#[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+impl<T: std::panic::UnwindSafe> CallbackUnwindSafe for T {}
+
+/// Bound carrying the unwind-safety requirement on [`Timeout::new`] /
+/// [`Interval::new`] callbacks.
+///
+/// Under `panic = "unwind"` on wasm the callback is invoked across a
+/// `catch_unwind` boundary inside `wasm_bindgen`, so this resolves to
+/// [`std::panic::UnwindSafe`]. Under any other panic strategy it is a no-op
+/// blanket. Wrap non-`UnwindSafe` captures in [`std::panic::AssertUnwindSafe`]
+/// at the call site.
+#[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+pub trait CallbackUnwindSafe {}
+#[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+impl<T> CallbackUnwindSafe for T {}
+
 #[wasm_bindgen]
 unsafe extern "C" {
     #[wasm_bindgen(js_name = "setTimeout", catch)]
@@ -57,8 +83,18 @@ impl Timeout {
     /// ```
     pub fn new<F>(millis: u32, callback: F) -> Timeout
     where
-        F: 'static + FnOnce(),
+        F: 'static + FnOnce() + CallbackUnwindSafe,
     {
+        // Under `panic = "unwind"` we use the `_assert_unwind_safe` variant
+        // because `WasmClosureFnOnce` selection erases `F` into a trait-object
+        // dispatch that no longer carries the static `UnwindSafe` bound — the
+        // same dyn-erasure problem wasm-bindgen handles internally. The
+        // `CallbackUnwindSafe` bound on the public API has already enforced
+        // the requirement at the call site. On any other panic strategy
+        // `Closure::once` is unchanged and works on any 0.2.x wasm-bindgen.
+        #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+        let closure = Closure::once_assert_unwind_safe(callback);
+        #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
         let closure = Closure::once(callback);
 
         let id = set_timeout(
@@ -158,8 +194,17 @@ impl Interval {
     /// ```
     pub fn new<F>(millis: u32, callback: F) -> Interval
     where
-        F: 'static + FnMut(),
+        F: 'static + FnMut() + CallbackUnwindSafe,
     {
+        // Same rationale as `Timeout::new`: the `Box<F> as Box<dyn FnMut()>`
+        // coercion erases the `UnwindSafe` bound, so under `panic = "unwind"`
+        // we use `_assert_unwind_safe` to acknowledge the erasure (the public
+        // `CallbackUnwindSafe` bound has already enforced unwind safety at
+        // the call site). Otherwise the original `Closure::wrap` path is
+        // preserved for older wasm-bindgen compatibility.
+        #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+        let closure = Closure::wrap_assert_unwind_safe(Box::new(callback) as Box<dyn FnMut()>);
+        #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
         let closure = Closure::wrap(Box::new(callback) as Box<dyn FnMut()>);
 
         let id = set_interval(

--- a/crates/timers/src/callback.rs
+++ b/crates/timers/src/callback.rs
@@ -17,14 +17,7 @@ pub trait CallbackUnwindSafe: std::panic::UnwindSafe {}
 #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
 impl<T: std::panic::UnwindSafe> CallbackUnwindSafe for T {}
 
-/// Bound carrying the unwind-safety requirement on [`Timeout::new`] /
-/// [`Interval::new`] callbacks.
-///
-/// Under `panic = "unwind"` on wasm the callback is invoked across a
-/// `catch_unwind` boundary inside `wasm_bindgen`, so this resolves to
-/// [`std::panic::UnwindSafe`]. Under any other panic strategy it is a no-op
-/// blanket. Wrap non-`UnwindSafe` captures in [`std::panic::AssertUnwindSafe`]
-/// at the call site.
+#[doc(hidden)]
 #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
 pub trait CallbackUnwindSafe {}
 #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]

--- a/crates/timers/src/future.rs
+++ b/crates/timers/src/future.rs
@@ -5,10 +5,22 @@ use crate::callback::{Interval, Timeout};
 use futures_channel::{mpsc, oneshot};
 use futures_core::stream::Stream;
 use std::convert::TryFrom;
+use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 use wasm_bindgen::prelude::*;
+
+/// Unwrap an `AssertUnwindSafe<T>` by-value without triggering RFC 2229
+/// field-level disjoint capture inside a closure. Writing `w.0` or
+/// `let AssertUnwindSafe(x) = w` inside a `move` closure causes the closure
+/// to capture the inner `T` instead of the `AssertUnwindSafe<T>` wrapper,
+/// silently losing the unwind-safety assertion. Routing through a function
+/// call forces capture of the wrapper.
+#[inline(always)]
+fn unwrap_assert_unwind_safe<T>(w: AssertUnwindSafe<T>) -> T {
+    w.0
+}
 
 /// A scheduled timeout as a `Future`.
 ///
@@ -66,9 +78,20 @@ impl TimeoutFuture {
     /// ```
     pub fn new(millis: u32) -> TimeoutFuture {
         let (tx, rx) = oneshot::channel();
+        // `oneshot::Sender` holds an `Arc<Inner<T>>` whose interior is an
+        // `UnsafeCell`-backed lock, so it is not `UnwindSafe`. The assertion
+        // is sound: the closure is `FnOnce`, `tx` is consumed by `send`, and
+        // nothing observes the sender after the callback returns. `rx` takes
+        // the same lock on poll and treats a missing payload as "cancelled".
+        //
+        // The wrapper is unwound by a helper rather than `let _(x) = w;` or
+        // `w.0` so that RFC 2229 disjoint-capture sees the closure capturing
+        // `AssertUnwindSafe<Sender<()>>` (UnwindSafe) and not the inner
+        // `Sender<()>` (!UnwindSafe). See the discussion in PR #563.
+        let tx = AssertUnwindSafe(tx);
         let inner = Timeout::new(millis, move || {
             // if the receiver was dropped we do nothing.
-            tx.send(()).unwrap_throw();
+            unwrap_assert_unwind_safe(tx).send(()).unwrap_throw();
         });
         TimeoutFuture { _inner: inner, rx }
     }
@@ -140,6 +163,21 @@ impl IntervalStream {
     /// ```
     pub fn new(millis: u32) -> IntervalStream {
         let (sender, receiver) = mpsc::unbounded();
+        // `mpsc::UnboundedSender` shares state with the receiver through an
+        // `Arc<Inner<T>>` with `UnsafeCell` interior, so it is not
+        // `UnwindSafe`. The assertion is sound: `unbounded_send` is a
+        // lock-free push that either completes or doesn't, and the only
+        // realistic panic site (allocation) aborts under default config; if
+        // a future ticks observes an inconsistent queue it can at worst
+        // hang, not violate memory safety.
+        //
+        // `unbounded_send` takes `&self`, so the method call autoderefs
+        // through `AssertUnwindSafe`'s `Deref` impl and the closure captures
+        // `AssertUnwindSafe<UnboundedSender<()>>` rather than projecting to
+        // the inner `Sender`. Avoid rewriting as `sender.0.unbounded_send(...)`
+        // — that explicit `.0` defeats the wrapper under RFC 2229
+        // disjoint-capture inference.
+        let sender = AssertUnwindSafe(sender);
         let inner = Interval::new(millis, move || {
             // if the receiver was dropped we do nothing.
             sender.unbounded_send(()).unwrap_throw();

--- a/crates/timers/src/future.rs
+++ b/crates/timers/src/future.rs
@@ -87,7 +87,7 @@ impl TimeoutFuture {
         // The wrapper is unwound by a helper rather than `let _(x) = w;` or
         // `w.0` so that RFC 2229 disjoint-capture sees the closure capturing
         // `AssertUnwindSafe<Sender<()>>` (UnwindSafe) and not the inner
-        // `Sender<()>` (!UnwindSafe). See the discussion in PR #563.
+        // `Sender<()>` (!UnwindSafe). See the discussion in PR #562.
         let tx = AssertUnwindSafe(tx);
         let inner = Timeout::new(millis, move || {
             // if the receiver was dropped we do nothing.

--- a/crates/worker/src/actor/native_worker.rs
+++ b/crates/worker/src/actor/native_worker.rs
@@ -46,7 +46,20 @@ macro_rules! worker_ext_impl {
                     let msg = CODEC::decode(message.data());
                     handler(msg);
                 };
-                let closure = Closure::wrap(Box::new(handler) as Box<dyn Fn(MessageEvent)>).into_js_value();
+                // wasm-bindgen 0.2.117+ requires `MaybeUnwindSafe` on closure
+                // inputs under `panic = "unwind"`; the `Box<F> as Box<dyn Fn>`
+                // coercion erases that bound. The internal callers (spawner,
+                // registrar) supply handlers that touch `Rc<RefCell<...>>` of
+                // worker state via `borrow_mut().take()` patterns that release
+                // borrows before invoking nested user code, so a panic across
+                // the `catch_unwind` boundary leaves no observable invariant
+                // violation. Asserting unwind safety here is sound. On other
+                // panic strategies this is plain `Closure::wrap`.
+                let inner = Box::new(handler) as Box<dyn Fn(MessageEvent)>;
+                #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
+                let closure = Closure::wrap_assert_unwind_safe(inner).into_js_value();
+                #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
+                let closure = Closure::wrap(inner).into_js_value();
                 self.set_onmessage(Some(closure.as_ref().unchecked_ref()));
             }
 


### PR DESCRIPTION
wasm-bindgen 0.2.117+ added `MaybeUnwindSafe` bounds on `Closure::wrap` and `Closure::once` because closures handed to JS are invoked across a `catch_unwind` boundary under `panic = "unwind"`. Every gloo crate that wraps user (or internal) `Fn`/`FnMut`/`FnOnce` callbacks fails to compile under `-Cpanic=unwind` because the `Box::new(callback) as Box<dyn Fn*>` coercion (and the `FnOnce` trait selection) erases the static `UnwindSafe` bound that wasm-bindgen requires.

This breaks every downstream crate that pulls in gloo and tests under `-Cpanic=unwind` — see the failure on https://github.com/MattiasBuelens/wasm-streams/pull/35.

The fix follows the same pattern in every affected crate:

* Where user callbacks flow through the public API (gloo-timers, gloo-events, gloo-render), surface the requirement via a `CallbackUnwindSafe` marker trait. It resolves to `std::panic::UnwindSafe` under `panic = "unwind"` on wasm and to a no-op blanket otherwise. Callers with non-`UnwindSafe` captures must wrap them in `std::panic::AssertUnwindSafe` at the call site, which is where the invariants can actually be reasoned about.

* Where the closures are purely internal (gloo-net websocket/eventsource, gloo-worker actor trampoline, gloo-timers futures wrappers, gloo-render's internal slot), use `Closure::wrap_assert_unwind_safe` / `Closure::once_assert_unwind_safe` under panic=unwind. The unwind-safety assertion is audited per call site: every internal closure either touches lock-free `mpsc::UnboundedSender` pushes, single-shot `Option<Waker>` takes, or `Rc<RefCell<...>>` slots where the borrow is released before invoking nested user code. A panic mid-callback leaves observers seeing only states already reachable by normal operation (a missing wake, a dropped event).

* All under-panic=unwind code paths are cfg-gated, so default `panic = "abort"` builds are byte-for-byte unchanged and remain compatible with any 0.2.x wasm-bindgen. No version-requirement bumps anywhere.

```rs
// before
pub fn new<F>(millis: u32, callback: F) -> Timeout
where F: 'static + FnOnce(),
{
    let closure = Closure::once(callback);
    ...
}
```

```rs
// after
pub fn new<F>(millis: u32, callback: F) -> Timeout
where F: 'static + FnOnce() + CallbackUnwindSafe,
{
    #[cfg(all(target_arch = "wasm32", panic = "unwind"))]
    let closure = Closure::once_assert_unwind_safe(callback);
    #[cfg(not(all(target_arch = "wasm32", panic = "unwind")))]
    let closure = Closure::once(callback);
    ...
}
```

This is not a breaking change. Under `panic = "abort"` (the default) `CallbackUnwindSafe` is a blanket implemented for every `T`, so the bound is invisible. Every existing caller continues to compile unchanged. Under `panic = "unwind"` gloo previously did not compile at all against wasm-bindgen 0.2.117+, so there are no existing panic=unwind callers to break. The change unblocks the configuration; it does not regress it.

The `panic_unwind_build` CI job now exercises every affected crate, not just gloo-timers default-features, so the regression cannot recur silently in any sibling crate. The nightly-pin workaround is also dropped: the upstream LLVM 22 + `panic=unwind` issue (wasm-bindgen#4929) is resolved.

Tested locally:

* `RUSTFLAGS="-Cpanic=unwind" cargo +nightly build -p gloo-timers -p gloo-events -p gloo-render -p gloo-net -p gloo-worker --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind` — passes.
* `cargo build -p gloo-timers --features futures --target wasm32-unknown-unknown` under both panic strategies — passes.
* Default-strategy `cargo check` + `cargo clippy` on all touched crates — clean.